### PR TITLE
Fix crash when mapmodding an invalid tile

### DIFF
--- a/src/EventManager.cpp
+++ b/src/EventManager.cpp
@@ -487,7 +487,9 @@ bool EventManager::executeEvent(Event &ev) {
 			}
 			else {
 				int index = distance(mapr->layernames.begin(), find(mapr->layernames.begin(), mapr->layernames.end(), ec->s));
-				if (ec->x >= 0 && ec->x < 256 && ec->y >= 0 && ec->y < 256)
+				if (!mapr->isValidTile(ec->z))
+					logError("EventManager: Mapmod at position (%d, %d) contains invalid tile id (%d).\n", ec->x, ec->y, ec->z);
+				else if (ec->x >= 0 && ec->x < 256 && ec->y >= 0 && ec->y < 256)
 					mapr->layers[index][ec->x][ec->y] = ec->z;
 				else
 					logError("EventManager: Mapmod at position (%d, %d) is out of bounds 0-255.\n", ec->x, ec->y);

--- a/src/MapRenderer.cpp
+++ b/src/MapRenderer.cpp
@@ -855,6 +855,13 @@ void MapRenderer::activatePower(int power_index, unsigned statblock_index, FPoin
 	}
 }
 
+bool MapRenderer::isValidTile(const unsigned &tile) {
+	if (tile >= tset.tiles.size())
+		return false;
+
+	return tset.tiles[tile].tile != NULL;
+}
+
 MapRenderer::~MapRenderer() {
 	if (music != NULL) {
 		Mix_HaltMusic();

--- a/src/MapRenderer.h
+++ b/src/MapRenderer.h
@@ -107,6 +107,8 @@ public:
 	// some events can trigger powers
 	void activatePower(int power_index, unsigned statblock_index, FPoint &target);
 
+	bool isValidTile(const unsigned &tile);
+
 	// cam(x,y) is where on the map the camera is pointing
 	FPoint cam;
 


### PR DESCRIPTION
Blank tiles do not have a surface associated with them, so the crash
would happen when attempting to render these tiles. We bypass this by
preventing mapmod from changing the tile in the first place.