### PR TITLE
Add internal newline to logging functions for non-SDL2 builds

### DIFF
--- a/src/Animation.cpp
+++ b/src/Animation.cpp
@@ -49,7 +49,7 @@ Animation::Animation(const std::string &_name, const std::string &_type, Image *
 	, active_frames()
 	, elapsed_frames(0) {
 	if (type == NONE)
-		logError("Animation: Type %s is unknown\n", _type.c_str());
+		logError("Animation: Type %s is unknown", _type.c_str());
 }
 
 Animation::Animation(const Animation& a)
@@ -120,12 +120,12 @@ void Animation::addFrame(	unsigned short index,
 							Point _render_offset) {
 
 	if (index >= gfx.size()/max_kinds) {
-		logError("Animation: Animation(%s) adding rect(%d, %d, %d, %d) to frame index(%u) out of bounds. must be in [0, %d]\n",
+		logError("Animation: Animation(%s) adding rect(%d, %d, %d, %d) to frame index(%u) out of bounds. must be in [0, %d]",
 				name.c_str(), rect.x, rect.y, rect.w, rect.h, index, (int)gfx.size()/max_kinds);
 		return;
 	}
 	if (kind > max_kinds-1) {
-		logError("Animation: Animation(%s) adding rect(%d, %d, %d, %d) to frame(%u) kind(%u) out of bounds. must be in [0, %d]\n",
+		logError("Animation: Animation(%s) adding rect(%d, %d, %d, %d) to frame(%u) kind(%u) out of bounds. must be in [0, %d]",
 				name.c_str(), rect.x, rect.y, rect.w, rect.h, index, kind, max_kinds-1);
 		return;
 	}
@@ -223,12 +223,12 @@ bool Animation::syncTo(const Animation *other) {
 
 	if (cur_frame_index >= frames.size()) {
 		if (frames.empty()) {
-			logError("Animation: '%s' animation has no frames, but current frame index is greater than 0.\n", name.c_str());
+			logError("Animation: '%s' animation has no frames, but current frame index is greater than 0.", name.c_str());
 			cur_frame_index = 0;
 			return false;
 		}
 		else {
-			logError("Animation: Current frame index (%d) was larger than the last frame index (%d) when syncing '%s' animation.\n", cur_frame_index, frames.size()-1, name.c_str());
+			logError("Animation: Current frame index (%d) was larger than the last frame index (%d) when syncing '%s' animation.", cur_frame_index, frames.size()-1, name.c_str());
 			cur_frame_index = frames.size()-1;
 			return false;
 		}

--- a/src/AnimationManager.cpp
+++ b/src/AnimationManager.cpp
@@ -30,7 +30,7 @@ AnimationSet *AnimationManager::getAnimationSet(const std::string& filename) {
 		return sets[index];
 	}
 	else {
-		logError("AnimationManager::getAnimationSet: %s not found\n", filename.c_str());
+		logError("AnimationManager::getAnimationSet: %s not found", filename.c_str());
 		SDL_Quit();
 		exit(1);
 		// return 0;
@@ -45,9 +45,9 @@ AnimationManager::~AnimationManager() {
 // NDEBUG is used by posix to disable assertions, so use the same MACRO.
 #ifndef NDEBUG
 	if (!names.empty()) {
-		logError("AnimationManager: Still holding these animations:\n");
+		logError("AnimationManager: Still holding these animations:");
 		for (unsigned i = 0; i < names.size(); i++)
-			logError("%s %d\n", names[i].c_str(), counts[i]);
+			logError("%s %d", names[i].c_str(), counts[i]);
 	}
 	assert(names.size() == 0);
 #endif
@@ -74,7 +74,7 @@ void AnimationManager::decreaseCount(const std::string &name) {
 		counts[index]--;
 	}
 	else {
-		logError("AnimationManager::decreaseCount: %s not found\n", name.c_str());
+		logError("AnimationManager::decreaseCount: %s not found", name.c_str());
 		SDL_Quit();
 		exit(1);
 	}

--- a/src/Avatar.cpp
+++ b/src/Avatar.cpp
@@ -213,7 +213,7 @@ void Avatar::loadGraphics(std::vector<Layer_gfx> _img_gfx) {
 			anims.push_back(animsets.back()->getAnimation(activeAnimation->getName()));
 			setAnimation("stance");
 			if(!anims.back()->syncTo(activeAnimation)) {
-				logError("Avatar: Error syncing animation in '%s' to 'animations/hero.txt'.\n", animsets.back()->getName().c_str());
+				logError("Avatar: Error syncing animation in '%s' to 'animations/hero.txt'.", animsets.back()->getName().c_str());
 			}
 		}
 		else {
@@ -257,7 +257,7 @@ void Avatar::loadStepFX(const std::string& stepname) {
 	}
 
 	// Could not find step sound fx
-	logError("Avatar: Could not find footstep sounds for '%s'.\n", filename.c_str());
+	logError("Avatar: Could not find footstep sounds for '%s'.", filename.c_str());
 }
 
 
@@ -741,7 +741,7 @@ void Avatar::transform() {
 		charmed_stats->load(el.type);
 	}
 	else {
-		logError("Avatar: Could not transform into creature type '%s'\n", stats.transform_type.c_str());
+		logError("Avatar: Could not transform into creature type '%s'", stats.transform_type.c_str());
 		stats.transform_type = "";
 		return;
 	}

--- a/src/EnemyGroupManager.cpp
+++ b/src/EnemyGroupManager.cpp
@@ -79,7 +79,7 @@ Enemy_Level EnemyGroupManager::getRandomEnemy(const std::string& category, int m
 		enemyCategory = it->second;
 	}
 	else {
-		logError("EnemyGroupManager: Could not find enemy category %s, returning empty enemy\n", category.c_str());
+		logError("EnemyGroupManager: Could not find enemy category %s, returning empty enemy", category.c_str());
 		return Enemy_Level();
 	}
 
@@ -101,7 +101,7 @@ Enemy_Level EnemyGroupManager::getRandomEnemy(const std::string& category, int m
 				add_times = 1;
 			}
 			else {
-				logError("EnemyGroupManager: 'rarity' property for enemy '%s' not valid (common|uncommon|rare): %s\n",
+				logError("EnemyGroupManager: 'rarity' property for enemy '%s' not valid (common|uncommon|rare): %s",
 						new_enemy.type.c_str(), new_enemy.rarity.c_str());
 			}
 
@@ -113,7 +113,7 @@ Enemy_Level EnemyGroupManager::getRandomEnemy(const std::string& category, int m
 	}
 
 	if (enemyCandidates.empty()) {
-		logError("EnemyGroupManager: Could not find a suitable enemy category for (%s, %d, %d)\n", category.c_str(), minlevel, maxlevel);
+		logError("EnemyGroupManager: Could not find a suitable enemy category for (%s, %d, %d)", category.c_str(), minlevel, maxlevel);
 		return Enemy_Level();
 	}
 	else {

--- a/src/EnemyManager.cpp
+++ b/src/EnemyManager.cpp
@@ -58,7 +58,7 @@ Enemy *EnemyManager::getEnemyPrototype(const std::string& type_id) {
 	e.type = type_id;
 
 	if (e.stats.animations == "")
-		logError("EnemyManager: No animation file specified for entity: %s\n", type_id.c_str());
+		logError("EnemyManager: No animation file specified for entity: %s", type_id.c_str());
 
 	loadAnimations(&e);
 	e.loadSounds();
@@ -97,7 +97,7 @@ void EnemyManager::handleNewMap () {
 		mapr->enemies.pop();
 
 		if (me.type.empty()) {
-			logError("EnemyManager: Enemy(%f, %f) doesn't have type attribute set, skipping\n", me.pos.x, me.pos.y);
+			logError("EnemyManager: Enemy(%f, %f) doesn't have type attribute set, skipping", me.pos.x, me.pos.y);
 			continue;
 		}
 
@@ -187,7 +187,7 @@ void EnemyManager::handleSpawn() {
 			e->stats.load(el.type);
 		}
 		else {
-			logError("EnemyManager: Could not spawn creature type '%s'\n", espawn.type.c_str());
+			logError("EnemyManager: Could not spawn creature type '%s'", espawn.type.c_str());
 			delete e;
 			return;
 		}
@@ -199,10 +199,10 @@ void EnemyManager::handleSpawn() {
 			if (e->animationSet)
 				e->activeAnimation = e->animationSet->getAnimation();
 			else
-				logError("EnemyManager: Animations file could not be loaded for %s\n", espawn.type.c_str());
+				logError("EnemyManager: Animations file could not be loaded for %s", espawn.type.c_str());
 		}
 		else {
-			logError("EnemyManager: No animation file specified for entity: %s\n", espawn.type.c_str());
+			logError("EnemyManager: No animation file specified for entity: %s", espawn.type.c_str());
 		}
 		e->loadSounds();
 

--- a/src/Entity.cpp
+++ b/src/Entity.cpp
@@ -130,7 +130,7 @@ void Entity::move_from_offending_tile() {
 	// offending tile. The idea is simple: We can only be stuck on a tile by accident,
 	// so we got here somehow. We'll try to push this entity to the nearest valid place
 	while (!mapr->collider.is_valid_position(stats.pos.x, stats.pos.y, stats.movement_type, stats.hero)) {
-		logError("Entity: %s got stuck on an invalid tile. Please report this bug, if you're able to reproduce it!\n",
+		logError("Entity: %s got stuck on an invalid tile. Please report this bug, if you're able to reproduce it!",
 				stats.hero ? "The hero" : "An entity");
 
 		float pushx = 0;
@@ -158,7 +158,7 @@ void Entity::move_from_offending_tile() {
 		if (pushx == 0 && pushy == 0) {
 			stats.pos.x = randBetween(1, mapr->w-1) + 0.5f;
 			stats.pos.y = randBetween(1, mapr->h-1) + 0.5f;
-			logError("Entity: %s got stuck on an invalid tile. Please report this bug, if you're able to reproduce it!\n",
+			logError("Entity: %s got stuck on an invalid tile. Please report this bug, if you're able to reproduce it!",
 					stats.hero ? "The hero" : "An entity");
 		}
 	}
@@ -450,7 +450,7 @@ bool Entity::setAnimation(const std::string& animationName) {
 	activeAnimation = animationSet->getAnimation(animationName);
 
 	if (activeAnimation == NULL)
-		logError("Entity::setAnimation(%s): not found\n", animationName.c_str());
+		logError("Entity::setAnimation(%s): not found", animationName.c_str());
 
 	return activeAnimation == NULL;
 }

--- a/src/EventManager.cpp
+++ b/src/EventManager.cpp
@@ -483,16 +483,16 @@ bool EventManager::executeEvent(Event &ev) {
 				if (ec->x >= 0 && ec->x < 256 && ec->y >= 0 && ec->y < 256)
 					mapr->collider.colmap[ec->x][ec->y] = ec->z;
 				else
-					logError("EventManager: Mapmod at position (%d, %d) is out of bounds 0-255.\n", ec->x, ec->y);
+					logError("EventManager: Mapmod at position (%d, %d) is out of bounds 0-255.", ec->x, ec->y);
 			}
 			else {
 				int index = distance(mapr->layernames.begin(), find(mapr->layernames.begin(), mapr->layernames.end(), ec->s));
 				if (!mapr->isValidTile(ec->z))
-					logError("EventManager: Mapmod at position (%d, %d) contains invalid tile id (%d).\n", ec->x, ec->y, ec->z);
+					logError("EventManager: Mapmod at position (%d, %d) contains invalid tile id (%d).", ec->x, ec->y, ec->z);
 				else if (ec->x >= 0 && ec->x < 256 && ec->y >= 0 && ec->y < 256)
 					mapr->layers[index][ec->x][ec->y] = ec->z;
 				else
-					logError("EventManager: Mapmod at position (%d, %d) is out of bounds 0-255.\n", ec->x, ec->y);
+					logError("EventManager: Mapmod at position (%d, %d) is out of bounds 0-255.", ec->x, ec->y);
 			}
 			mapr->map_change = true;
 		}

--- a/src/FileParser.cpp
+++ b/src/FileParser.cpp
@@ -45,7 +45,7 @@ bool FileParser::open(const std::string& _filename, bool locateFileName, const s
 	this->errormessage = _errormessage;
 
 	if (filenames.size() == 0 && !errormessage.empty()) {
-		logError("FileParser: %s: %s: No such file or directory!\n", _filename.c_str(), errormessage.c_str());
+		logError("FileParser: %s: %s: No such file or directory!", _filename.c_str(), errormessage.c_str());
 		return false;
 	}
 
@@ -85,7 +85,7 @@ bool FileParser::open(const std::string& _filename, bool locateFileName, const s
 		}
 		else {
 			if (!errormessage.empty())
-				logError("FileParser: %s: %s\n", errormessage.c_str(), filenames[i-1].c_str());
+				logError("FileParser: %s: %s", errormessage.c_str(), filenames[i-1].c_str());
 			infile.clear();
 		}
 	}
@@ -152,7 +152,7 @@ bool FileParser::next() {
 		infile.open(current_filename.c_str(), std::ios::in);
 		if (!infile.is_open()) {
 			if (!errormessage.empty())
-				logError("FileParser: %s: %s\n", errormessage.c_str(), current_filename.c_str());
+				logError("FileParser: %s: %s", errormessage.c_str(), current_filename.c_str());
 			infile.clear();
 			return false;
 		}
@@ -206,7 +206,7 @@ void FileParser::error(const char* format, ...) {
 	va_end(args);
 
 	std::stringstream ss;
-	ss << "[" << filenames[current_index] << ":" << line_number << "] " << buffer << std::endl;
+	ss << "[" << filenames[current_index] << ":" << line_number << "] " << buffer;
 	logError(ss.str().c_str());
 }
 

--- a/src/FontEngine.cpp
+++ b/src/FontEngine.cpp
@@ -36,7 +36,7 @@ FontEngine::FontEngine()
 	, cursor_y(0) {
 	// Initiate SDL_ttf
 	if(!TTF_WasInit() && TTF_Init()==-1) {
-		logError("FontEngine: TTF_Init: %s\n", TTF_GetError());
+		logError("FontEngine: TTF_Init: %s", TTF_GetError());
 		exit(2);
 	}
 
@@ -61,7 +61,7 @@ FontEngine::FontEngine()
 				style->blend = toBool(popFirstString(infile.val));
 				style->ttfont = TTF_OpenFont(mods->locate("fonts/" + style->path).c_str(), style->ptsize);
 				if(style->ttfont == NULL) {
-					logError("FontEngine: TTF_OpenFont: %s\n", TTF_GetError());
+					logError("FontEngine: TTF_OpenFont: %s", TTF_GetError());
 				}
 				else {
 					int lineskip = TTF_FontLineSkip(style->ttfont);
@@ -89,7 +89,7 @@ FontEngine::FontEngine()
 	// Attempt to set the default active font
 	setFont("font_regular");
 	if (!active_font) {
-		logError("FontEngine: Unable to determine default font!\n");
+		logError("FontEngine: Unable to determine default font!");
 		SDL_Quit();
 		exit(1);
 	}
@@ -217,7 +217,7 @@ void FontEngine::render(const std::string& text, int x, int y, int justify, Imag
 		dest_rect.y = y;
 	}
 	else {
-		logError("FontEngine::render() given unhandled 'justify=%d', assuming left\n",justify);
+		logError("FontEngine::render() given unhandled 'justify=%d', assuming left",justify);
 		dest_rect.x = x;
 		dest_rect.y = y;
 	}

--- a/src/GameStateConfigBase.cpp
+++ b/src/GameStateConfigBase.cpp
@@ -795,7 +795,7 @@ bool GameStateConfigBase::setMods() {
 		}
 	}
 	if (outfile.bad())
-		logError("GameStateConfigBase: Unable to save mod list into file. No write access or disk is full!\n");
+		logError("GameStateConfigBase: Unable to save mod list into file. No write access or disk is full!");
 
 	outfile.close();
 	outfile.clear();

--- a/src/GameStateConfigDesktop.cpp
+++ b/src/GameStateConfigDesktop.cpp
@@ -90,7 +90,7 @@ GameStateConfigDesktop::GameStateConfigDesktop()
 {
 	// Populate the resolution list
 	if (getVideoModes() < 1)
-		logError("GameStateConfigDesktop: Unable to get resolutions list!\n");
+		logError("GameStateConfigDesktop: Unable to get resolutions list!");
 
 	// Allocate KeyBindings
 	for (int i = 0; i < inpt->key_count; i++) {

--- a/src/GameStateCutscene.cpp
+++ b/src/GameStateCutscene.cpp
@@ -56,7 +56,7 @@ Image *Scene::loadImage(std::string filename, bool scale_graphics) {
 				image = resized;
 		}
 		else {
-			logError("GameStateCutscene: Can not scale cutscene image with a width of 0.\n");
+			logError("GameStateCutscene: Can not scale cutscene image with a width of 0.");
 		}
 	}
 
@@ -264,7 +264,7 @@ bool GameStateCutscene::load(std::string filename) {
 	infile.close();
 
 	if (scenes.empty()) {
-		logError("GameStateCutscene: No scenes defined in cutscene file %s\n", filename.c_str());
+		logError("GameStateCutscene: No scenes defined in cutscene file %s", filename.c_str());
 		return false;
 	}
 

--- a/src/GameStateLoad.cpp
+++ b/src/GameStateLoad.cpp
@@ -157,7 +157,7 @@ GameStateLoad::GameStateLoad() : GameState()
 		}
 		infile.close();
 	}
-	if (!found_layer) logError("GameStateLoad: Could not find layers for direction 6\n");
+	if (!found_layer) logError("GameStateLoad: Could not find layers for direction 6");
 
 	button_action->pos.x += (VIEW_W - FRAME_W)/2;
 	button_action->pos.y += (VIEW_H - FRAME_H)/2;
@@ -369,7 +369,7 @@ void GameStateLoad::loadPreview(int slot) {
 
 	for (unsigned int i=0; i<equipped[slot].size(); i++) {
 		if ((unsigned)equipped[slot][i] > items->items.size()-1) {
-			logError("GameStateLoad: Item in save slot %d with id=%d is out of bounds 1-%d. Your savegame is broken or you might be using an incompatible savegame/mod\n", slot+1, equipped[slot][i], (int)items->items.size()-1);
+			logError("GameStateLoad: Item in save slot %d with id=%d is out of bounds 1-%d. Your savegame is broken or you might be using an incompatible savegame/mod", slot+1, equipped[slot][i], (int)items->items.size()-1);
 			continue;
 		}
 
@@ -500,7 +500,7 @@ void GameStateLoad::logic() {
 					ss << SAVE_PREFIX << "_";
 				ss << "stash_HC" << (selected_slot+1) << ".txt";
 				if (remove(ss.str().c_str()) != 0)
-					logError("GameStateLoad: Error deleting hardcore stash in slot %d\n", selected_slot+1);
+					logError("GameStateLoad: Error deleting hardcore stash in slot %d", selected_slot+1);
 			}
 
 			stats[selected_slot] = StatBlock();

--- a/src/GameStatePlay.cpp
+++ b/src/GameStatePlay.cpp
@@ -305,7 +305,7 @@ void GameStatePlay::checkTeleport() {
 				mapr->respawn_point = pc->stats.pos;
 			}
 			else {
-				logError("GameStatePlay: Spawn position (%d, %d) is blocked.\n", (int)pc->stats.pos.x, (int)pc->stats.pos.y);
+				logError("GameStatePlay: Spawn position (%d, %d) is blocked.", (int)pc->stats.pos.x, (int)pc->stats.pos.y);
 			}
 
 			// return to title (permadeath) OR auto-save
@@ -326,7 +326,7 @@ void GameStatePlay::checkTeleport() {
 					ss << SAVE_PREFIX << "_";
 				ss << "stash_HC" << game_slot << ".txt";
 				if (remove(ss.str().c_str()) != 0)
-					logError("GameStatePlay: Error deleting hardcore stash in slot %d\n", game_slot);
+					logError("GameStatePlay: Error deleting hardcore stash in slot %d", game_slot);
 
 				delete requestedGameState;
 				requestedGameState = new GameStateTitle();
@@ -918,7 +918,7 @@ void GameStatePlay::logic() {
 			menu->act->locked[count] = true;
 		}
 		else if (pc->stats.manual_untransform && pc->untransform_power == 0)
-			logError("GameStatePlay: Untransform power not found, you can't untransform manually\n");
+			logError("GameStatePlay: Untransform power not found, you can't untransform manually");
 
 		menu->act->updated = true;
 

--- a/src/GameStateResolution.cpp
+++ b/src/GameStateResolution.cpp
@@ -111,7 +111,7 @@ void GameStateResolution::render() {
  */
 bool GameStateResolution::applyVideoSettings(int width, int height) {
 	if (MIN_VIEW_W > width && MIN_VIEW_H > height) {
-		logError("GameStateResolution: A mod is requiring a minimum resolution of %dx%d\n", MIN_VIEW_W, MIN_VIEW_H);
+		logError("GameStateResolution: A mod is requiring a minimum resolution of %dx%d", MIN_VIEW_W, MIN_VIEW_H);
 		if (width < MIN_VIEW_W) width = MIN_VIEW_W;
 		if (height < MIN_VIEW_H) height = MIN_VIEW_H;
 	}
@@ -121,7 +121,7 @@ bool GameStateResolution::applyVideoSettings(int width, int height) {
 
 	// If the new settings fail, revert to the old ones
 	if (status == -1) {
-		logError("GameStateResolution: Error during SDL_SetVideoMode: %s\n", SDL_GetError());
+		logError("GameStateResolution: Error during SDL_SetVideoMode: %s", SDL_GetError());
 		FULLSCREEN = old_fullscreen;
 		HWSURFACE = old_hwsurface;
 		DOUBLEBUF = old_doublebuf;

--- a/src/GameSwitcher.cpp
+++ b/src/GameSwitcher.cpp
@@ -81,7 +81,7 @@ void GameSwitcher::loadMusic() {
 		if (music_filename != "") {
 			music = Mix_LoadMUS((mods->locate(music_filename)).c_str());
 			if (!music)
-				logError("GameSwitcher: Mix_LoadMUS: %s\n", Mix_GetError());
+				logError("GameSwitcher: Mix_LoadMUS: %s", Mix_GetError());
 		}
 	}
 

--- a/src/InputState.cpp
+++ b/src/InputState.cpp
@@ -244,7 +244,7 @@ void InputState::saveKeyBindings() {
 		outfile << "actionbar_use=" << binding[ACTIONBAR_USE] << "," << binding_alt[ACTIONBAR_USE] << "," << binding_joy[ACTIONBAR_USE] << "\n";
 		outfile << "developer_menu=" << binding[DEVELOPER_MENU] << "," << binding_alt[DEVELOPER_MENU] << "," << binding_joy[DEVELOPER_MENU] << "\n";
 
-		if (outfile.bad()) logError("InputState: Unable to write keybindings config file. No write access or disk is full!\n");
+		if (outfile.bad()) logError("InputState: Unable to write keybindings config file. No write access or disk is full!");
 		outfile.close();
 		outfile.clear();
 	}

--- a/src/ItemManager.cpp
+++ b/src/ItemManager.cpp
@@ -103,8 +103,8 @@ void ItemManager::loadAll() {
 	shrinkVecToFit(item_sets);
 
 	// do we need to print these messages?
-	if (items.empty()) logInfo("ItemManager: No items were found.\n");
-	if (item_sets.empty()) logInfo("ItemManager: No item sets were found.\n");
+	if (items.empty()) logInfo("ItemManager: No items were found.");
+	if (item_sets.empty()) logInfo("ItemManager: No item sets were found.");
 }
 
 /**
@@ -238,7 +238,7 @@ void ItemManager::loadItems() {
 			else if (s == "defense")
 				items[id].req_stat.push_back(REQUIRES_DEF);
 			else
-				infile.error("%s unrecognized at; requires_stat must be one of [physical:mental:offense:defense]\n", s.c_str());
+				infile.error("%s unrecognized at; requires_stat must be one of [physical:mental:offense:defense]", s.c_str());
 			items[id].req_val.push_back(toInt(infile.nextValue()));
 		}
 		else if (infile.key == "requires_class") {
@@ -752,11 +752,11 @@ bool ItemStack::empty() {
 		return false;
 	}
 	else if (item == 0 && quantity != 0) {
-		logError("ItemStack: Item id is zero, but quantity is %d.\n", quantity);
+		logError("ItemStack: Item id is zero, but quantity is %d.", quantity);
 		quantity = 0;
 	}
 	else if (item != 0 && quantity == 0) {
-		logError("ItemStack: Item id is %d, but quantity is zero.\n", item);
+		logError("ItemStack: Item id is %d, but quantity is zero.", item);
 		item = 0;
 	}
 	return true;

--- a/src/ItemStorage.cpp
+++ b/src/ItemStorage.cpp
@@ -48,15 +48,15 @@ void ItemStorage::setItems(std::string s) {
 		storage[i].item = popFirstInt(s, ',');
 		// check if such item exists to avoid crash if savegame was modified manually
 		if (storage[i].item < 0) {
-			logError("ItemStorage: Item on position %d has negative id, skipping\n", i);
+			logError("ItemStorage: Item on position %d has negative id, skipping", i);
 			storage[i].clear();
 		}
 		else if ((unsigned)storage[i].item > items->items.size()-1) {
-			logError("ItemStorage: Item id (%d) out of bounds 1-%d, marking as unknown\n", storage[i].item, (int)items->items.size());
+			logError("ItemStorage: Item id (%d) out of bounds 1-%d, marking as unknown", storage[i].item, (int)items->items.size());
 			items->addUnknownItem(storage[i].item);
 		}
 		else if (storage[i].item != 0 && items->items[storage[i].item].name == "") {
-			logError("ItemStorage: Item with id=%d. found on position %d does not exist, marking as unknown\n", storage[i].item, i);
+			logError("ItemStorage: Item with id=%d. found on position %d does not exist, marking as unknown", storage[i].item, i);
 			items->addUnknownItem(storage[i].item);
 		}
 	}
@@ -70,7 +70,7 @@ void ItemStorage::setQuantities(std::string s) {
 	for (int i=0; i<slot_number; i++) {
 		storage[i].quantity = popFirstInt(s, ',');
 		if (storage[i].quantity < 0) {
-			logError("ItemStorage: Items quantity on position %d is negative, setting to zero\n", i);
+			logError("ItemStorage: Items quantity on position %d is negative, setting to zero", i);
 			storage[i].quantity = 0;
 		}
 	}
@@ -267,11 +267,11 @@ bool ItemStorage::contain(int item, int quantity) {
 void ItemStorage::clean() {
 	for (int i=0; i<slot_number; i++) {
 		if (storage[i].item > 0 && storage[i].quantity < 1) {
-			logInfo("ItemStorage: Removing item with id %d, which has a quantity of 0\n",storage[i].item);
+			logInfo("ItemStorage: Removing item with id %d, which has a quantity of 0",storage[i].item);
 			storage[i].clear();
 		}
 		else if (storage[i].item == 0 && storage[i].quantity != 0) {
-			logInfo("ItemStorage: Removing item with id 0, which has a quantity of %d\n", storage[i].quantity);
+			logInfo("ItemStorage: Removing item with id 0, which has a quantity of %d", storage[i].quantity);
 			storage[i].clear();
 		}
 	}

--- a/src/LootManager.cpp
+++ b/src/LootManager.cpp
@@ -251,7 +251,7 @@ void LootManager::addEnemyLoot(Enemy *e) {
 
 void LootManager::checkLoot(std::vector<Event_Component> &loot_table, FPoint *pos) {
 	if (hero == NULL) {
-		logError("LootManager: checkLoot() failed, no hero.\n");
+		logError("LootManager: checkLoot() failed, no hero.");
 		return;
 	}
 

--- a/src/Map.cpp
+++ b/src/Map.cpp
@@ -105,7 +105,7 @@ int Map::load(std::string fname) {
 			StatBlock *statb = &statblocks.back();
 
 			if (!statb) {
-				logError("Map: Could not create StatBlock for Event.\n");
+				logError("Map: Could not create StatBlock for Event.");
 				continue;
 			}
 

--- a/src/MapRenderer.cpp
+++ b/src/MapRenderer.cpp
@@ -146,7 +146,7 @@ void MapRenderer::pushEnemyGroup(Map_Group &g) {
 
 	}
 	if (enemies_to_spawn) {
-		logError("MapRenderer: Could not spawn all enemies in group at %s (x=%d,y=%d,w=%d,h=%d), %d missing (min=%d max=%d)\n",
+		logError("MapRenderer: Could not spawn all enemies in group at %s (x=%d,y=%d,w=%d,h=%d), %d missing (min=%d max=%d)",
 				filename.c_str(), g.pos.x, g.pos.y, g.area.x, g.area.y, enemies_to_spawn, g.numbermin, g.numbermax);
 	}
 }
@@ -209,9 +209,9 @@ int MapRenderer::load(std::string fname) {
 	}
 
 	if (!corrupted.empty()) {
-		logError("MapRenderer: Tileset or Map corrupted. A tile has a larger id than the tileset allows or is undefined.\n");
+		logError("MapRenderer: Tileset or Map corrupted. A tile has a larger id than the tileset allows or is undefined.");
 		while (!corrupted.empty()) {
-			logError("MapRenderer: Removing offending tile id %d.\n", corrupted.back());
+			logError("MapRenderer: Removing offending tile id %d.", corrupted.back());
 			corrupted.pop_back();
 		}
 	}
@@ -239,7 +239,7 @@ void MapRenderer::loadMusic() {
 	if (AUDIO && MUSIC_VOLUME) {
 		music = Mix_LoadMUS(mods->locate(played_music_filename).c_str());
 		if(!music)
-			logError("MapRenderer: Mix_LoadMUS: %s\n", Mix_GetError());
+			logError("MapRenderer: Mix_LoadMUS: %s", Mix_GetError());
 	}
 
 	if (music) {
@@ -851,7 +851,7 @@ void MapRenderer::activatePower(int power_index, unsigned statblock_index, FPoin
 		}
 	}
 	else {
-		logError("MapRenderer: StatBlock index is out of bounds.\n");
+		logError("MapRenderer: StatBlock index is out of bounds.");
 	}
 }
 

--- a/src/MenuInventory.cpp
+++ b/src/MenuInventory.cpp
@@ -541,7 +541,7 @@ void MenuInventory::activate(Point position) {
 				items->playSound(inventory[EQUIPMENT][equip_slot].item);
 			}
 		}
-		else logError("MenuInventory: Can't find equip slot, corresponding to type %s\n", items->items[inventory[CARRIED][slot].item].type.c_str());
+		else logError("MenuInventory: Can't find equip slot, corresponding to type %s", items->items[inventory[CARRIED][slot].item].type.c_str());
 	}
 
 	drag_prev_src = -1;

--- a/src/MenuPowers.cpp
+++ b/src/MenuPowers.cpp
@@ -928,7 +928,7 @@ void MenuPowers::loadPower(FileParser &infile) {
 		power_cell.pop_back();
 		slots.pop_back();
 		upgradeButtons.pop_back();
-		logError("MenuPowers: There is a power without a valid id as the first attribute.\nIDs must be the first attribute in the power menu definition.\n");
+		logError("MenuPowers: There is a power without a valid id as the first attribute. IDs must be the first attribute in the power menu definition.");
 	}
 
 	if (skip_section)

--- a/src/MessageEngine.cpp
+++ b/src/MessageEngine.cpp
@@ -35,7 +35,7 @@ MessageEngine::MessageEngine() {
 
 	std::vector<std::string> engineFiles = mods->list("languages/engine." + LANGUAGE + ".po");
 	if (engineFiles.size() == 0 && LANGUAGE != "en")
-		logError("MessageEngine: Unable to open basic translation files located in languages/engine.%s.po\n", LANGUAGE.c_str());
+		logError("MessageEngine: Unable to open basic translation files located in languages/engine.%s.po", LANGUAGE.c_str());
 
 	for (unsigned i = 0; i < engineFiles.size(); ++i) {
 		if (infile.open(engineFiles[i])) {
@@ -47,7 +47,7 @@ MessageEngine::MessageEngine() {
 
 	std::vector<std::string> dataFiles = mods->list("languages/data." + LANGUAGE + ".po");
 	if (dataFiles.size() == 0 && LANGUAGE != "en")
-		logError("MessageEngine: Unable to open basic translation files located in languages/data.%s.po\n", LANGUAGE.c_str());
+		logError("MessageEngine: Unable to open basic translation files located in languages/data.%s.po", LANGUAGE.c_str());
 
 	for (unsigned i = 0; i < dataFiles.size(); ++i) {
 		if (infile.open(dataFiles[i])) {

--- a/src/ModManager.cpp
+++ b/src/ModManager.cpp
@@ -108,8 +108,8 @@ void ModManager::loadModList() {
 		infile.open(place2.c_str(), std::ios::in);
 	}
 	if (!infile.is_open()) {
-		logError("ModManager: Error during loadModList() -- couldn't open mods.txt, to be located at \n");
-		logError("%s\n%s\n\n", place1.c_str(), place2.c_str());
+		logError("ModManager: Error during loadModList() -- couldn't open mods.txt, to be located at:");
+		logError("%s\n%s\n", place1.c_str(), place2.c_str());
 	}
 
 	while (infile.good()) {
@@ -129,7 +129,7 @@ void ModManager::loadModList() {
 				found_any_mod = true;
 			}
 			else {
-				logError("ModManager: Mod \"%s\" not found, skipping\n", line.c_str());
+				logError("ModManager: Mod \"%s\" not found, skipping", line.c_str());
 			}
 		}
 	}
@@ -139,7 +139,7 @@ void ModManager::loadModList() {
 		logError("ModManager: Couldn't locate any Flare mod. Check if the game data are installed \
                   correctly. Expected to find the data in the $XDG_DATA_DIRS path, in \
 				  /usr/local/share/flare/mods, or in the same folder as the executable. \
-				  Try placing the mods folder in one of these locations.\n");
+				  Try placing the mods folder in one of these locations.");
 	}
 }
 
@@ -296,7 +296,7 @@ void ModManager::applyDepends() {
 	for (unsigned i=0; i<mod_list.size(); i++) {
 		// skip the mod if the game doesn't match
 		if (mod_list[i].game != game && mod_list[i].name != FALLBACK_MOD) {
-			logError("ModManager: Tried to enable \"%s\", but failed. Game does not match \"%s\".\n", mod_list[i].name.c_str(), game.c_str());
+			logError("ModManager: Tried to enable \"%s\", but failed. Game does not match \"%s\".", mod_list[i].name.c_str(), game.c_str());
 			continue;
 		}
 
@@ -304,7 +304,7 @@ void ModManager::applyDepends() {
 		if (compareVersions(mod_list[i].min_version_major, mod_list[i].min_version_minor, VERSION_MAJOR, VERSION_MINOR) ||
 		    compareVersions(VERSION_MAJOR, VERSION_MINOR, mod_list[i].max_version_major, mod_list[i].max_version_minor)) {
 
-			logError("ModManager: Tried to enable \"%s\", but failed. Not compatible with engine version %d.%02d.\n", mod_list[i].name.c_str(), VERSION_MAJOR, VERSION_MINOR);
+			logError("ModManager: Tried to enable \"%s\", but failed. Not compatible with engine version %d.%02d.", mod_list[i].name.c_str(), VERSION_MAJOR, VERSION_MINOR);
 			continue;
 		}
 
@@ -328,26 +328,26 @@ void ModManager::applyDepends() {
 					if (find(mod_dirs.begin(), mod_dirs.end(), mod_list[i].depends[j]) != mod_dirs.end()) {
 						Mod new_depend = loadMod(mod_list[i].depends[j]);
 						if (new_depend.game != game) {
-							logError("ModManager: Tried to enable dependency \"%s\" for \"%s\", but failed. Game does not match \"%s\".\n", new_depend.name.c_str(), mod_list[i].name.c_str(), game.c_str());
+							logError("ModManager: Tried to enable dependency \"%s\" for \"%s\", but failed. Game does not match \"%s\".", new_depend.name.c_str(), mod_list[i].name.c_str(), game.c_str());
 							depends_met = false;
 							break;
 						}
 						else if (compareVersions(new_depend.min_version_major, new_depend.min_version_minor, VERSION_MAJOR, VERSION_MINOR) ||
 						         compareVersions(VERSION_MAJOR, VERSION_MINOR, new_depend.max_version_major, new_depend.max_version_minor)) {
 
-							logError("ModManager: Tried to enable dependency \"%s\" for \"%s\", but failed. Not compatible with engine version %d.%02d.\n", new_depend.name.c_str(), mod_list[i].name.c_str(), VERSION_MAJOR, VERSION_MINOR);
+							logError("ModManager: Tried to enable dependency \"%s\" for \"%s\", but failed. Not compatible with engine version %d.%02d.", new_depend.name.c_str(), mod_list[i].name.c_str(), VERSION_MAJOR, VERSION_MINOR);
 							depends_met = false;
 							break;
 						}
 						else if (std::find(new_mods.begin(), new_mods.end(), new_depend) == new_mods.end()) {
-							logError("ModManager: Mod \"%s\" requires the \"%s\" mod. Enabling \"%s\" now.\n", mod_list[i].name.c_str(), mod_list[i].depends[j].c_str(), mod_list[i].depends[j].c_str());
+							logError("ModManager: Mod \"%s\" requires the \"%s\" mod. Enabling \"%s\" now.", mod_list[i].name.c_str(), mod_list[i].depends[j].c_str(), mod_list[i].depends[j].c_str());
 							new_mods.push_back(new_depend);
 							finished = false;
 							break;
 						}
 					}
 					else {
-						logError("ModManager: Could not find mod \"%s\", which is required by mod \"%s\". Disabling \"%s\" now.\n", mod_list[i].depends[j].c_str(), mod_list[i].name.c_str(), mod_list[i].name.c_str());
+						logError("ModManager: Could not find mod \"%s\", which is required by mod \"%s\". Disabling \"%s\" now.", mod_list[i].depends[j].c_str(), mod_list[i].name.c_str(), mod_list[i].name.c_str());
 						depends_met = false;
 						break;
 					}

--- a/src/RenderDevice.cpp
+++ b/src/RenderDevice.cpp
@@ -178,10 +178,10 @@ RenderDevice::~RenderDevice() {
 void RenderDevice::destroyContext() {
 	if (!cache.empty()) {
 		IMAGE_CACHE_CONTAINER_ITER it;
-		logError("RenderDevice: Image cache still holding these images:\n");
+		logError("RenderDevice: Image cache still holding these images:");
 		it = cache.begin();
 		while (it != cache.end()) {
-			logError("%s %d\n", it->first.c_str(), it->second->getRefCount());
+			logError("%s %d", it->first.c_str(), it->second->getRefCount());
 			++it;
 		}
 	}
@@ -192,7 +192,6 @@ Image * RenderDevice::cacheLookup(std::string &filename) {
 	IMAGE_CACHE_CONTAINER_ITER it;
 	it = cache.find(filename);
 	if (it != cache.end()) {
-		// logError("RenderDevice: %p %s reused from image cache.\n", it->second, filename.c_str());
 		it->second->ref();
 		return it->second;
 	}
@@ -202,7 +201,6 @@ Image * RenderDevice::cacheLookup(std::string &filename) {
 void RenderDevice::cacheStore(std::string &filename, Image *image) {
 	if (image == NULL) return;
 	cache[filename] = image;
-	// logError("RenderDevice: %p %s stored in image cache.\n", image, filename.c_str());
 }
 
 void RenderDevice::cacheRemove(Image *image) {
@@ -214,7 +212,6 @@ void RenderDevice::cacheRemove(Image *image) {
 	}
 
 	if (it != cache.end()) {
-		// logError("RenderDevice: %p %s removed from image cache.\n", it->second, it->first.c_str());
 		cache.erase(it);
 	}
 }

--- a/src/RenderDeviceList.cpp
+++ b/src/RenderDeviceList.cpp
@@ -34,7 +34,7 @@ RenderDevice* getRenderDevice(std::string name) {
 		else if (name == "sdl_hardware") return new SDLHardwareRenderDevice();
 #endif
 		else {
-			logError("RenderDeviceList: Render device '%s' not found. Falling back to the default.\n", name.c_str());
+			logError("RenderDeviceList: Render device '%s' not found. Falling back to the default.", name.c_str());
 			return new SDLSoftwareRenderDevice();
 		}
 	}

--- a/src/SDLHardwareRenderDevice.cpp
+++ b/src/SDLHardwareRenderDevice.cpp
@@ -215,7 +215,7 @@ int SDLHardwareRenderDevice::createContext(int width, int height) {
 		return 0;
 	}
 	else {
-		logError("SDLHardwareRenderDevice: createContext() failed: %s\n", SDL_GetError());
+		logError("SDLHardwareRenderDevice: createContext() failed: %s", SDL_GetError());
 		SDL_Quit();
 		exit(1);
 	}
@@ -454,7 +454,7 @@ Image *SDLHardwareRenderDevice::createImage(int width, int height) {
 	if (width > 0 && height > 0) {
 		image->surface = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_ARGB8888, SDL_TEXTUREACCESS_TARGET, width, height);
 		if(image->surface == NULL) {
-			logError("SDLHardwareRenderDevice: SDL_CreateTexture failed: %s\n", SDL_GetError());
+			logError("SDLHardwareRenderDevice: SDL_CreateTexture failed: %s", SDL_GetError());
 		}
 		else {
 				SDL_SetRenderTarget(renderer, image->surface);
@@ -519,7 +519,7 @@ Image *SDLHardwareRenderDevice::loadImage(std::string filename, std::string erro
 	if(image->surface == NULL) {
 		delete image;
 		if (!errormessage.empty())
-			logError("SDLHardwareRenderDevice: %s: %s\n", errormessage.c_str(), IMG_GetError());
+			logError("SDLHardwareRenderDevice: %s: %s", errormessage.c_str(), IMG_GetError());
 		if (IfNotFoundExit) {
 			SDL_Quit();
 			exit(1);

--- a/src/SDLSoftwareRenderDevice.cpp
+++ b/src/SDLSoftwareRenderDevice.cpp
@@ -196,9 +196,9 @@ SDLSoftwareRenderDevice::SDLSoftwareRenderDevice()
 	, titlebar_icon(NULL)
 	, title(NULL) {
 #if SDL_VERSION_ATLEAST(2,0,0)
-	logInfo("Using Render Device: SDLSoftwareRenderDevice (software, SDL 2)\n");
+	logInfo("Using Render Device: SDLSoftwareRenderDevice (software, SDL 2)");
 #else
-	logInfo("Using Render Device: SDLSoftwareRenderDevice (software, SDL 1.2)\n");
+	logInfo("Using Render Device: SDLSoftwareRenderDevice (software, SDL 1.2)");
 #endif
 }
 
@@ -547,7 +547,7 @@ Image *SDLSoftwareRenderDevice::createImage(int width, int height) {
 #endif
 
 	if(image->surface == NULL) {
-		logError("SDLSoftwareRenderDevice: CreateRGBSurface failed: %s\n", SDL_GetError());
+		logError("SDLSoftwareRenderDevice: CreateRGBSurface failed: %s", SDL_GetError());
 		delete image;
 		return NULL;
 	}
@@ -608,13 +608,13 @@ void SDLSoftwareRenderDevice::listModes(std::vector<Rect> &modes) {
 
 	// Check if there are any modes available
 	if (detect_modes == (SDL_Rect**)0) {
-		logError("SDLSoftwareRenderDevice: No modes available!\n");
+		logError("SDLSoftwareRenderDevice: No modes available!");
 		return;
 	}
 
 	// Check if our resolution is restricted
 	if (detect_modes == (SDL_Rect**)-1) {
-		logError("SDLSoftwareRenderDevice: All resolutions available.\n");
+		logError("SDLSoftwareRenderDevice: All resolutions available.");
 	}
 
 	for (unsigned i=0; detect_modes[i]; ++i) {
@@ -649,7 +649,7 @@ Image *SDLSoftwareRenderDevice::loadImage(std::string filename, std::string erro
 	SDL_Surface *cleanup = IMG_Load(mods->locate(filename).c_str());
 	if(!cleanup) {
 		if (!errormessage.empty())
-			logError("SDLSoftwareRenderDevice: %s: %s\n", errormessage.c_str(), IMG_GetError());
+			logError("SDLSoftwareRenderDevice: %s: %s", errormessage.c_str(), IMG_GetError());
 		if (IfNotFoundExit) {
 			SDL_Quit();
 			exit(1);

--- a/src/SaveLoad.cpp
+++ b/src/SaveLoad.cpp
@@ -154,7 +154,7 @@ void GameStatePlay::saveGame() {
 
 		outfile << std::endl;
 
-		if (outfile.bad()) logError("SaveLoad: Unable to save the game. No write access or disk is full!\n");
+		if (outfile.bad()) logError("SaveLoad: Unable to save the game. No write access or disk is full!");
 		outfile.close();
 		outfile.clear();
 	}
@@ -181,7 +181,7 @@ void GameStatePlay::saveGame() {
 
 		outfile << std::endl;
 
-		if (outfile.bad()) logError("SaveLoad: Unable to save stash. No write access or disk is full!\n");
+		if (outfile.bad()) logError("SaveLoad: Unable to save stash. No write access or disk is full!");
 		outfile.close();
 		outfile.clear();
 	}
@@ -244,7 +244,7 @@ void GameStatePlay::loadGame() {
 						pc->stats.offense_character < 0 || pc->stats.offense_character > pc->stats.max_points_per_stat ||
 						pc->stats.defense_character < 0 || pc->stats.defense_character > pc->stats.max_points_per_stat) {
 
-					logError("SaveLoad: Some basic stats are out of bounds, setting to zero\n");
+					logError("SaveLoad: Some basic stats are out of bounds, setting to zero");
 					pc->stats.physical_character = 0;
 					pc->stats.mental_character = 0;
 					pc->stats.offense_character = 0;
@@ -276,7 +276,7 @@ void GameStatePlay::loadGame() {
 					mapr->clearEvents();
 				}
 				else {
-					logError("SaveLoad: Unable to find %s, loading maps/spawn.txt\n", mapr->teleport_mapname.c_str());
+					logError("SaveLoad: Unable to find %s, loading maps/spawn.txt", mapr->teleport_mapname.c_str());
 					mapr->teleport_mapname = "maps/spawn.txt";
 					mapr->teleport_destination.x = 1;
 					mapr->teleport_destination.y = 1;
@@ -287,15 +287,15 @@ void GameStatePlay::loadGame() {
 				for (int i = 0; i < ACTIONBAR_MAX; i++) {
 					hotkeys[i] = toInt(infile.nextValue());
 					if (hotkeys[i] < 0) {
-						logError("SaveLoad: Hotkey power on position %d has negative id, skipping\n", i);
+						logError("SaveLoad: Hotkey power on position %d has negative id, skipping", i);
 						hotkeys[i] = 0;
 					}
 					else if ((unsigned)hotkeys[i] > powers->powers.size()-1) {
-						logError("SaveLoad: Hotkey power id (%d) out of bounds 1-%d, skipping\n", hotkeys[i], (int)powers->powers.size());
+						logError("SaveLoad: Hotkey power id (%d) out of bounds 1-%d, skipping", hotkeys[i], (int)powers->powers.size());
 						hotkeys[i] = 0;
 					}
 					else if (hotkeys[i] != 0 && (unsigned)hotkeys[i] < powers->powers.size() && powers->powers[hotkeys[i]].name == "") {
-						logError("SaveLoad: Hotkey power with id=%d, found on position %d does not exist, skipping\n", hotkeys[i], i);
+						logError("SaveLoad: Hotkey power with id=%d, found on position %d does not exist, skipping", hotkeys[i], i);
 						hotkeys[i] = 0;
 					}
 				}
@@ -320,7 +320,7 @@ void GameStatePlay::loadGame() {
 
 		infile.close();
 	}
-	else logError("SaveLoad: Unable to open %s!\n", ss.str().c_str());
+	else logError("SaveLoad: Unable to open %s!", ss.str().c_str());
 
 	// add legacy currency to inventory
 	menu->inv->addCurrency(currency);
@@ -332,13 +332,13 @@ void GameStatePlay::loadGame() {
 	// powers->activatePassives(pc->stats);
 	if (SAVE_HPMP && saved_hp != 0) {
 		if (saved_hp < 0 || saved_hp > pc->stats.get(STAT_HP_MAX)) {
-			logError("SaveLoad: HP value is out of bounds, setting to maximum\n");
+			logError("SaveLoad: HP value is out of bounds, setting to maximum");
 			pc->stats.hp = pc->stats.get(STAT_HP_MAX);
 		}
 		else pc->stats.hp = saved_hp;
 
 		if (saved_mp < 0 || saved_mp > pc->stats.get(STAT_MP_MAX)) {
-			logError("SaveLoad: MP value is out of bounds, setting to maximum\n");
+			logError("SaveLoad: MP value is out of bounds, setting to maximum");
 			pc->stats.mp = pc->stats.get(STAT_MP_MAX);
 		}
 		else pc->stats.mp = saved_mp;
@@ -408,7 +408,7 @@ void GameStatePlay::loadStash() {
 		}
 		infile.close();
 	}
-	else logError("SaveLoad: Unable to open %s!\n", ss.str().c_str());
+	else logError("SaveLoad: Unable to open %s!", ss.str().c_str());
 
 	menu->stash->stock.clean();
 }

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -233,7 +233,7 @@ void setPaths() {
 
 	PATH_DATA = "";
 	if (dirExists(CUSTOM_PATH_DATA)) PATH_DATA = CUSTOM_PATH_DATA;
-	else if (!CUSTOM_PATH_DATA.empty()) logError("Settings: Could not find specified game data directory.\n");
+	else if (!CUSTOM_PATH_DATA.empty()) logError("Settings: Could not find specified game data directory.");
 
 	PATH_CONF = PATH_CONF + "/";
 	PATH_USER = PATH_USER + "/";
@@ -275,7 +275,7 @@ void setPaths() {
 	}
 	else
 	{
-		logError("Settings: Android external storage unavailable: %s\n", SDL_GetError());
+		logError("Settings: Android external storage unavailable: %s", SDL_GetError());
 	}
 
 	PATH_CONF = PATH_CONF + "/";
@@ -289,7 +289,7 @@ void setPaths() {
 	PATH_USER = "PROGDIR:";
 	PATH_DATA = "PROGDIR:";
 	if (dirExists(CUSTOM_PATH_DATA)) PATH_DATA = CUSTOM_PATH_DATA;
-	else if (!CUSTOM_PATH_DATA.empty()) logError("Settings: Could not find specified game data directory.\n");
+	else if (!CUSTOM_PATH_DATA.empty()) logError("Settings: Could not find specified game data directory.");
 }
 #else
 void setPaths() {
@@ -356,7 +356,7 @@ void setPaths() {
 		if (!path_data) PATH_DATA = CUSTOM_PATH_DATA;
 		path_data = true;
 	}
-	else if (!CUSTOM_PATH_DATA.empty()) logError("Settings: Could not find specified game data directory.\n");
+	else if (!CUSTOM_PATH_DATA.empty()) logError("Settings: Could not find specified game data directory.");
 
 	// Check for the local data before trying installed ones.
 	if (dirExists("./mods")) {
@@ -410,7 +410,7 @@ static ConfigEntry * getConfigEntry(const char * name) {
 		if (std::strcmp(config[i].name, name) == 0) return config + i;
 	}
 
-	logError("Settings: '%s' is not a valid configuration key.\n", name);
+	logError("Settings: '%s' is not a valid configuration key.", name);
 	return NULL;
 }
 
@@ -433,7 +433,7 @@ void loadTilesetSettings() {
 	FileParser infile;
 	// load tileset settings from engine config
 	// @CLASS Settings: Tileset config|Description of engine/tileset_config.txt
-	if (infile.open("engine/tileset_config.txt", true, "Unable to open engine/tileset_config.txt! Defaulting to 64x32 isometric tiles.\n")) {
+	if (infile.open("engine/tileset_config.txt", true, "Unable to open engine/tileset_config.txt! Defaulting to 64x32 isometric tiles.")) {
 		while (infile.next()) {
 			if (infile.key == "tile_size") {
 				// @ATTR tile_size|w (integet), h (integer)|The width and height of a tile.
@@ -465,7 +465,7 @@ void loadTilesetSettings() {
 			UNITS_PER_PIXEL_Y = 2.0f / TILE_H;
 		}
 		else {
-			logError("Settings: Tile dimensions must be greater than 0. Resetting to the default size of 64x32.\n");
+			logError("Settings: Tile dimensions must be greater than 0. Resetting to the default size of 64x32.");
 			TILE_W = 64;
 			TILE_H = 32;
 		}
@@ -476,13 +476,13 @@ void loadTilesetSettings() {
 			UNITS_PER_PIXEL_Y = 1.0f / TILE_H;
 		}
 		else {
-			logError("Settings: Tile dimensions must be greater than 0. Resetting to the default size of 64x32.\n");
+			logError("Settings: Tile dimensions must be greater than 0. Resetting to the default size of 64x32.");
 			TILE_W = 64;
 			TILE_H = 32;
 		}
 	}
 	if (UNITS_PER_PIXEL_X == 0 || UNITS_PER_PIXEL_Y == 0) {
-		logError("Settings: One of UNITS_PER_PIXEL values is zero! %dx%d\n", (int)UNITS_PER_PIXEL_X, (int)UNITS_PER_PIXEL_Y);
+		logError("Settings: One of UNITS_PER_PIXEL values is zero! %dx%d", (int)UNITS_PER_PIXEL_X, (int)UNITS_PER_PIXEL_Y);
 		SDL_Quit();
 		exit(1);
 	}
@@ -568,7 +568,7 @@ void loadMiscSettings() {
 				CURRENCY_ID = toInt(infile.val);
 				if (CURRENCY_ID < 1) {
 					CURRENCY_ID = 1;
-					logError("Settings: Currency ID below the minimum allowed value. Resetting it to %d\n", CURRENCY_ID);
+					logError("Settings: Currency ID below the minimum allowed value. Resetting it to %d", CURRENCY_ID);
 				}
 			}
 			// @ATTR interact_range|float|Distance where the player can interact with objects and NPCs.
@@ -840,7 +840,7 @@ bool saveSettings() {
 			outfile<<config[i].name<<"="<<toString(*config[i].type, config[i].storage)<<"\n";
 		}
 
-		if (outfile.bad()) logError("Settings: Unable to write settings file. No write access or disk is full!\n");
+		if (outfile.bad()) logError("Settings: Unable to write settings file. No write access or disk is full!");
 		outfile.close();
 		outfile.clear();
 	}

--- a/src/SoundManager.cpp
+++ b/src/SoundManager.cpp
@@ -178,7 +178,7 @@ SoundManager::SoundID SoundManager::load(const std::string& filename, const std:
 	lsnd.chunk = Mix_LoadWAV(realfilename.c_str());
 	lsnd.refCnt = 1;
 	if (!lsnd.chunk) {
-		logError("SoundManager: %s: Loading sound %s (%s) failed: %s \n", errormessage.c_str(),
+		logError("SoundManager: %s: Loading sound %s (%s) failed: %s", errormessage.c_str(),
 				realfilename.c_str(), filename.c_str(), Mix_GetError());
 		return 0;
 	}
@@ -245,7 +245,7 @@ void SoundManager::play(SoundManager::SoundID sid, std::string channel, FPoint p
 	int c = Mix_PlayChannel(-1, it->second->chunk, (loop ? -1 : 0));
 
 	if (c == -1)
-		logError("SoundManager: Failed to play sound, no more channels available.\n");
+		logError("SoundManager: Failed to play sound, no more channels available.");
 
 	// precalculate mixing volume if sound has a location
 	Uint8 d = 0;

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -270,6 +270,7 @@ void logInfo(const char* format, ...) {
 #else
 	printf("INFO: ");
 	vprintf(format, args);
+	printf("\n");
 #endif
 
 	va_end(args);
@@ -285,6 +286,7 @@ void logError(const char* format, ...) {
 #else
 	printf("ERROR: ");
 	vprintf(format, args);
+	printf("\n");
 #endif
 
 	va_end(args);

--- a/src/UtilsParsing.cpp
+++ b/src/UtilsParsing.cpp
@@ -53,7 +53,7 @@ int parse_duration(const std::string& s) {
 		val *= MAX_FRAMES_PER_SEC;
 	else {
 		if (suffix != "ms")
-			logError("UtilsParsing: Duration of '%d' does not have a suffix. Assuming 'ms'.\n", val);
+			logError("UtilsParsing: Duration of '%d' does not have a suffix. Assuming 'ms'.", val);
 		val = int(floor(((val*MAX_FRAMES_PER_SEC) / 1000.f) + 0.5f));
 	}
 
@@ -183,7 +183,7 @@ bool tryParseValue(const std::type_info & type, const std::string & value, void 
 		*((std::string *)output) = value;
 	}
 	else {
-		logError("UtilsParsing: %s: a required type is not defined!\n", __FUNCTION__);
+		logError("UtilsParsing: %s: a required type is not defined!", __FUNCTION__);
 		return false;
 	}
 
@@ -222,7 +222,7 @@ std::string toString(const std::type_info & type, void * value) {
 		return (std::string &)*((std::string *)value);
 	}
 	else {
-		logError("UtilsParsing: %s: a required type is not defined!\n", __FUNCTION__);
+		logError("UtilsParsing: %s: a required type is not defined!", __FUNCTION__);
 		return "";
 	}
 
@@ -261,7 +261,7 @@ bool toBool(std::string value) {
 	if (value == "no") return false;
 	if (value == "0") return false;
 
-	logError("UtilsParsing: %s %s doesn't know how to handle %s\n", __FILE__, __FUNCTION__, value.c_str());
+	logError("UtilsParsing: %s %s doesn't know how to handle %s", __FILE__, __FUNCTION__, value.c_str());
 	return false;
 }
 

--- a/src/WidgetTooltip.cpp
+++ b/src/WidgetTooltip.cpp
@@ -149,7 +149,7 @@ bool WidgetTooltip::createBuffer(TooltipData &tip) {
 	graphics = render_device->createImage(size.x + margin+margin, size.y + margin+margin);
 
 	if (!graphics) {
-		logError("WidgetTooltip: Could not create tooltip buffer.\n");
+		logError("WidgetTooltip: Could not create tooltip buffer.");
 		return false;
 	}
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -41,7 +41,7 @@ static void init(const std::string render_device_name) {
 
 	// SDL Inits
 	if ( SDL_Init (SDL_INIT_VIDEO | SDL_INIT_AUDIO | SDL_INIT_JOYSTICK) < 0 ) {
-		logError("main: Could not initialize SDL: %s\n", SDL_GetError());
+		logError("main: Could not initialize SDL: %s", SDL_GetError());
 		exit(1);
 	}
 
@@ -50,17 +50,17 @@ static void init(const std::string render_device_name) {
 	mods = new ModManager();
 
 	if (!mods->haveFallbackMod()) {
-		logError("main: Could not find the default mod in the following locations:\n");
-		if (dirExists(PATH_DATA + "mods")) logError("%smods/\n", PATH_DATA.c_str());
-		if (dirExists(PATH_USER + "mods")) logError("%smods/\n", PATH_USER.c_str());
-		logError("A copy of the default mod is in the \"mods\" directory of the flare-engine repo.\n");
-		logError("The repo is located at: https://github.com/clintbellanger/flare-engine\n");
-		logError("Try again after copying the default mod to one of the above directories.\nExiting.\n");
+		logError("main: Could not find the default mod in the following locations:");
+		if (dirExists(PATH_DATA + "mods")) logError("%smods/", PATH_DATA.c_str());
+		if (dirExists(PATH_USER + "mods")) logError("%smods/", PATH_USER.c_str());
+		logError("A copy of the default mod is in the \"mods\" directory of the flare-engine repo.");
+		logError("The repo is located at: https://github.com/clintbellanger/flare-engine");
+		logError("Try again after copying the default mod to one of the above directories. Exiting.");
 		exit(1);
 	}
 
 	if (!loadSettings()) {
-		logError("%s", ("main: Could not load settings file: ‘" + PATH_CONF + FILE_SETTINGS + "’.\n").c_str());
+		logError("%s", ("main: Could not load settings file: ‘" + PATH_CONF + FILE_SETTINGS + "’.").c_str());
 		exit(1);
 	}
 
@@ -83,7 +83,7 @@ static void init(const std::string render_device_name) {
 
 	if (status == -1) {
 
-		logError("main: Error during SDL_SetVideoMode: %s\n", SDL_GetError());
+		logError("main: Error during SDL_SetVideoMode: %s", SDL_GetError());
 		SDL_Quit();
 		exit(1);
 	}
@@ -96,7 +96,7 @@ static void init(const std::string render_device_name) {
 		render_device->setGamma(GAMMA);
 
 	if (AUDIO && Mix_OpenAudio(22050, AUDIO_S16SYS, 2, 1024)) {
-		logError("main: Error during Mix_OpenAudio: %s\n", SDL_GetError());
+		logError("main: Error during Mix_OpenAudio: %s", SDL_GetError());
 		AUDIO = false;
 	}
 
@@ -104,21 +104,21 @@ static void init(const std::string render_device_name) {
 
 	// initialize Joysticks
 	if(SDL_NumJoysticks() == 1) {
-		logInfo("1 joystick was found:\n");
+		logInfo("1 joystick was found:");
 	}
 	else if(SDL_NumJoysticks() > 1) {
-		logInfo("%d joysticks were found:\n", SDL_NumJoysticks());
+		logInfo("%d joysticks were found:", SDL_NumJoysticks());
 	}
 	else {
-		logInfo("No joysticks were found.\n");
+		logInfo("No joysticks were found.");
 		ENABLE_JOYSTICK = false;
 	}
 	for(int i = 0; i < SDL_NumJoysticks(); i++) {
-		logInfo("  Joy %d) %s\n", i, inpt->getJoystickName(i).c_str());
+		logInfo("  Joy %d) %s", i, inpt->getJoystickName(i).c_str());
 	}
 	if ((ENABLE_JOYSTICK) && (SDL_NumJoysticks() > 0)) {
 		joy = SDL_JoystickOpen(JOYSTICK_DEVICE);
-		logInfo("Using joystick #%d.\n", JOYSTICK_DEVICE);
+		logInfo("Using joystick #%d.", JOYSTICK_DEVICE);
 	}
 
 	// Set sound effects volume from settings file


### PR DESCRIPTION
SDL 2's logging functions automatically add a newline character when
printing a message. So we simply mimick that behavior when SDL 2 is not
available. This means that we no longer need to add a newline character
to the strings we pass to logInfo() and logError().