### PR TITLE
Prevent fast frames when resuming the game on Android

### DIFF
--- a/src/InputState.cpp
+++ b/src/InputState.cpp
@@ -43,6 +43,7 @@ InputState::InputState(void)
 	, lock_scroll(false)
 	, touch_locked(false)
 	, lock_all(false)
+	, window_minimized(false)
 	, current_touch() {
 #if SDL_VERSION_ATLEAST(2,0,0)
 	SDL_StartTextInput();
@@ -340,6 +341,14 @@ void InputState::handle(bool dump_event) {
 					}
 				}
 				last_button = event.button.button;
+				break;
+#else
+			// detect hiding Android app to trigger pausing
+			case SDL_WINDOWEVENT:
+				if (event.window.event == SDL_WINDOWEVENT_MINIMIZED)
+					window_minimized = true;
+				else if (event.window.event == SDL_WINDOWEVENT_RESTORED)
+					window_minimized = false;
 				break;
 #endif
 			// Android touch events

--- a/src/InputState.h
+++ b/src/InputState.h
@@ -108,6 +108,7 @@ public:
 	bool lock_scroll;
 	bool touch_locked;
 	bool lock_all;
+	bool window_minimized;
 
 private:
 	bool un_press[key_count];

--- a/src/MenuManager.cpp
+++ b/src/MenuManager.cpp
@@ -601,6 +601,11 @@ void MenuManager::logic() {
 		}
 	}
 
+	// pause the game when minimized (on Android)
+	if (inpt->window_minimized) {
+		exit->visible = true;
+	}
+
 	bool console_open = DEV_MODE && devconsole->visible;
 	menus_open = (inv->visible || pow->visible || chr->visible || log->visible || vendor->visible || talker->visible || npc->visible || book->visible || console_open);
 	pause = (MENUS_PAUSE && menus_open) || exit->visible || console_open;


### PR DESCRIPTION
This the same as our "pause game" functionality, except it is triggered
with an SDL_APP_DIDENTERFOREGROUND event. This event is equal to
onResume() for Android.

This is a possible fix for #1341, although I can't test it properly. @igorko Please test this when you get the chance.