### PR TITLE
Don't pause when restoring Android app, but do prevent frameskip

### DIFF
--- a/src/InputState.cpp
+++ b/src/InputState.cpp
@@ -44,6 +44,7 @@ InputState::InputState(void)
 	, touch_locked(false)
 	, lock_all(false)
 	, window_minimized(false)
+	, window_restored(false)
 	, current_touch() {
 #if SDL_VERSION_ATLEAST(2,0,0)
 	SDL_StartTextInput();
@@ -343,12 +344,12 @@ void InputState::handle(bool dump_event) {
 				last_button = event.button.button;
 				break;
 #else
-			// detect hiding Android app to trigger pausing
+			// detect restoring hidden Android app to bypass frameskip
 			case SDL_WINDOWEVENT:
 				if (event.window.event == SDL_WINDOWEVENT_MINIMIZED)
 					window_minimized = true;
 				else if (event.window.event == SDL_WINDOWEVENT_RESTORED)
-					window_minimized = false;
+					window_restored = true;
 				break;
 #endif
 			// Android touch events

--- a/src/InputState.h
+++ b/src/InputState.h
@@ -109,6 +109,7 @@ public:
 	bool touch_locked;
 	bool lock_all;
 	bool window_minimized;
+	bool window_restored;
 
 private:
 	bool un_press[key_count];

--- a/src/MenuManager.cpp
+++ b/src/MenuManager.cpp
@@ -601,11 +601,6 @@ void MenuManager::logic() {
 		}
 	}
 
-	// pause the game when minimized (on Android)
-	if (inpt->window_minimized) {
-		exit->visible = true;
-	}
-
 	bool console_open = DEV_MODE && devconsole->visible;
 	menus_open = (inv->visible || pow->visible || chr->visible || log->visible || vendor->visible || talker->visible || npc->visible || book->visible || console_open);
 	pause = (MENUS_PAUSE && menus_open) || exit->visible || console_open;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -152,6 +152,11 @@ static void mainLoop (bool debug_event) {
 
 			SDL_PumpEvents();
 			inpt->handle(debug_event);
+
+			// Skip game logic when minimized on Android
+			if (inpt->window_minimized && !inpt->window_restored)
+				break;
+
 			gswitch->logic();
 			inpt->resetScroll();
 
@@ -161,6 +166,16 @@ static void mainLoop (bool debug_event) {
 
 			logic_ticks += delay;
 			loops++;
+
+			// Android only
+			// When the app is minimized on Android, no logic gets processed.
+			// As a result, the delta time when restoring the app is large, so the game will skip frames and appear to be running fast.
+			// To counter this, we reset our delta time here when restoring the app
+			if (inpt->window_minimized && inpt->window_restored) {
+				logic_ticks = now_ticks;
+				inpt->window_minimized = inpt->window_restored = false;
+				break;
+			}
 
 			// don't skip frames if the game is paused
 			if (gswitch->isPaused()) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -172,7 +172,7 @@ static void mainLoop (bool debug_event) {
 			// As a result, the delta time when restoring the app is large, so the game will skip frames and appear to be running fast.
 			// To counter this, we reset our delta time here when restoring the app
 			if (inpt->window_minimized && inpt->window_restored) {
-				logic_ticks = now_ticks;
+				logic_ticks = now_ticks = SDL_GetTicks();
 				inpt->window_minimized = inpt->window_restored = false;
 				break;
 			}


### PR DESCRIPTION
The previous method of handling this involved pausing the game by
bringing up the pause menu. Unfortunately, this only worked for
GameStatePlay, since the other game states don't have pause menus.

This commit should be a better solution. Right before checking if the
game is paused, we now check if the game was minimized and is returning
to the foreground (minimized AND restored flags set). Here, we do the
same thing that is done when the game is paused: update the delta time
to prevent skipping frames.

@igorko I have successfully simulated testing of this on desktop and it worked for all the game states. However, you should test on Android to make sure. The code here is close to my original attempt at fixing the bug, but I had some of the logic in the wrong places.