### PR TITLE
Store save files in their own directories

### DIFF
--- a/src/GameStateLoad.cpp
+++ b/src/GameStateLoad.cpp
@@ -292,10 +292,7 @@ void GameStateLoad::readGameSlot(int slot) {
 	if (slot < 0 || slot >= GAME_SLOT_MAX) return;
 
 	// save slots are named save#.txt
-	filename << PATH_USER;
-	if (SAVE_PREFIX.length() > 0)
-		filename << SAVE_PREFIX << "_";
-	filename << "save" << (slot+1) << ".txt";
+	filename << PATH_USER << SAVE_PREFIX << "_save" << (slot+1) << ".txt";
 
 	if (!infile.open(filename.str(),false, "")) return;
 
@@ -482,11 +479,7 @@ void GameStateLoad::logic() {
 		confirm->logic();
 		if (confirm->confirmClicked) {
 			std::stringstream filename;
-			filename.str("");
-			filename << PATH_USER;
-			if (SAVE_PREFIX.length() > 0)
-				filename << SAVE_PREFIX << "_";
-			filename << "save" << (selected_slot+1) << ".txt";
+			filename << PATH_USER << SAVE_PREFIX << "_save" << (selected_slot+1) << ".txt";
 
 			if (remove(filename.str().c_str()) != 0)
 				logError("GameStateLoad: Error deleting save from path");
@@ -494,11 +487,7 @@ void GameStateLoad::logic() {
 			if (stats[selected_slot].permadeath) {
 				// Remove stash
 				std::stringstream ss;
-				ss.str("");
-				ss << PATH_USER;
-				if (SAVE_PREFIX.length() > 0)
-					ss << SAVE_PREFIX << "_";
-				ss << "stash_HC" << (selected_slot+1) << ".txt";
+				ss << PATH_USER << SAVE_PREFIX << "_stash_HC" << (selected_slot+1) << ".txt";
 				if (remove(ss.str().c_str()) != 0)
 					logError("GameStateLoad: Error deleting hardcore stash in slot %d", selected_slot+1);
 			}

--- a/src/GameStateLoad.cpp
+++ b/src/GameStateLoad.cpp
@@ -292,7 +292,7 @@ void GameStateLoad::readGameSlot(int slot) {
 	if (slot < 0 || slot >= GAME_SLOT_MAX) return;
 
 	// save data is stored in slot#/avatar.txt
-	filename << PATH_USER << SAVE_PREFIX << "/" << (slot+1) << "/avatar.txt";
+	filename << PATH_USER << "saves/" << SAVE_PREFIX << "/" << (slot+1) << "/avatar.txt";
 
 	if (!infile.open(filename.str(),false, "")) return;
 

--- a/src/GameStateLoad.cpp
+++ b/src/GameStateLoad.cpp
@@ -291,8 +291,8 @@ void GameStateLoad::readGameSlot(int slot) {
 	// abort if not a valid slot number
 	if (slot < 0 || slot >= GAME_SLOT_MAX) return;
 
-	// save slots are named save#.txt
-	filename << PATH_USER << SAVE_PREFIX << "_save" << (slot+1) << ".txt";
+	// save data is stored in slot#/avatar.txt
+	filename << PATH_USER << SAVE_PREFIX << "/" << (slot+1) << "/avatar.txt";
 
 	if (!infile.open(filename.str(),false, "")) return;
 
@@ -478,19 +478,7 @@ void GameStateLoad::logic() {
 	else if (confirm->visible) {
 		confirm->logic();
 		if (confirm->confirmClicked) {
-			std::stringstream filename;
-			filename << PATH_USER << SAVE_PREFIX << "_save" << (selected_slot+1) << ".txt";
-
-			if (remove(filename.str().c_str()) != 0)
-				logError("GameStateLoad: Error deleting save from path");
-
-			if (stats[selected_slot].permadeath) {
-				// Remove stash
-				std::stringstream ss;
-				ss << PATH_USER << SAVE_PREFIX << "_stash_HC" << (selected_slot+1) << ".txt";
-				if (remove(ss.str().c_str()) != 0)
-					logError("GameStateLoad: Error deleting hardcore stash in slot %d", selected_slot+1);
-			}
+			removeSaveDir(selected_slot+1);
 
 			stats[selected_slot] = StatBlock();
 			readGameSlot(selected_slot);

--- a/src/GameStatePlay.cpp
+++ b/src/GameStatePlay.cpp
@@ -310,16 +310,7 @@ void GameStatePlay::checkTeleport() {
 
 			// return to title (permadeath) OR auto-save
 			if (pc->stats.permadeath && pc->stats.corpse) {
-				std::stringstream filename;
-				filename << PATH_USER << SAVE_PREFIX << "_save" << game_slot << ".txt";
-				if (remove(filename.str().c_str()) != 0)
-					perror("Error deleting save from path");
-
-				// Remove stash
-				std::stringstream ss;
-				ss << PATH_USER << SAVE_PREFIX << "_stash_HC" << game_slot << ".txt";
-				if (remove(ss.str().c_str()) != 0)
-					logError("GameStatePlay: Error deleting hardcore stash in slot %d", game_slot);
+				removeSaveDir(game_slot);
 
 				delete requestedGameState;
 				requestedGameState = new GameStateTitle();

--- a/src/GameStatePlay.cpp
+++ b/src/GameStatePlay.cpp
@@ -311,20 +311,13 @@ void GameStatePlay::checkTeleport() {
 			// return to title (permadeath) OR auto-save
 			if (pc->stats.permadeath && pc->stats.corpse) {
 				std::stringstream filename;
-				filename << PATH_USER;
-				if (SAVE_PREFIX.length() > 0)
-					filename << SAVE_PREFIX << "_";
-				filename << "save" << game_slot << ".txt";
+				filename << PATH_USER << SAVE_PREFIX << "_save" << game_slot << ".txt";
 				if (remove(filename.str().c_str()) != 0)
 					perror("Error deleting save from path");
 
 				// Remove stash
 				std::stringstream ss;
-				ss.str("");
-				ss << PATH_USER;
-				if (SAVE_PREFIX.length() > 0)
-					ss << SAVE_PREFIX << "_";
-				ss << "stash_HC" << game_slot << ".txt";
+				ss << PATH_USER << SAVE_PREFIX << "_stash_HC" << game_slot << ".txt";
 				if (remove(ss.str().c_str()) != 0)
 					logError("GameStatePlay: Error deleting hardcore stash in slot %d", game_slot);
 

--- a/src/SaveLoad.cpp
+++ b/src/SaveLoad.cpp
@@ -63,7 +63,7 @@ void GameStatePlay::saveGame() {
 	std::ofstream outfile;
 
 	std::stringstream ss;
-	ss << PATH_USER << SAVE_PREFIX << "/" << game_slot << "/avatar.txt";
+	ss << PATH_USER << "saves/" << SAVE_PREFIX << "/" << game_slot << "/avatar.txt";
 
 	outfile.open(ss.str().c_str(), std::ios::out);
 
@@ -162,9 +162,9 @@ void GameStatePlay::saveGame() {
 	// Save stash
 	ss.str("");
 	if (pc->stats.permadeath)
-		ss << PATH_USER << SAVE_PREFIX << "/" << game_slot << "/stash_HC.txt";
+		ss << PATH_USER << "saves/" << SAVE_PREFIX << "/" << game_slot << "/stash_HC.txt";
 	else
-		ss << PATH_USER << SAVE_PREFIX << "/stash.txt";
+		ss << PATH_USER << "saves/" << SAVE_PREFIX << "/stash.txt";
 
 	outfile.open(ss.str().c_str(), std::ios::out);
 
@@ -203,7 +203,7 @@ void GameStatePlay::loadGame() {
 	std::vector<int> hotkeys(ACTIONBAR_MAX, -1);
 
 	std::stringstream ss;
-	ss << PATH_USER << SAVE_PREFIX << "/" << game_slot << "/avatar.txt";
+	ss << PATH_USER << "saves/" << SAVE_PREFIX << "/" << game_slot << "/avatar.txt";
 
 	if (infile.open(ss.str(), false)) {
 		while (infile.next()) {
@@ -382,9 +382,9 @@ void GameStatePlay::loadStash() {
 	FileParser infile;
 	std::stringstream ss;
 	if (pc->stats.permadeath)
-		ss << PATH_USER << SAVE_PREFIX << "/" << game_slot << "/stash_HC.txt";
+		ss << PATH_USER << "saves/" << SAVE_PREFIX << "/" << game_slot << "/stash_HC.txt";
 	else
-		ss << PATH_USER << SAVE_PREFIX << "/stash.txt";
+		ss << PATH_USER << "saves/" << SAVE_PREFIX << "/stash.txt";
 
 	if (infile.open(ss.str(), false)) {
 		while (infile.next()) {

--- a/src/SaveLoad.cpp
+++ b/src/SaveLoad.cpp
@@ -59,11 +59,7 @@ void GameStatePlay::saveGame() {
 	std::ofstream outfile;
 
 	std::stringstream ss;
-	ss.str("");
-	ss << PATH_USER;
-	if (SAVE_PREFIX.length() > 0)
-		ss << SAVE_PREFIX << "_";
-	ss << "save" << game_slot << ".txt";
+	ss << PATH_USER << SAVE_PREFIX << "_save" << game_slot << ".txt";
 
 	outfile.open(ss.str().c_str(), std::ios::out);
 
@@ -161,10 +157,7 @@ void GameStatePlay::saveGame() {
 
 	// Save stash
 	ss.str("");
-	ss << PATH_USER;
-	if (SAVE_PREFIX.length() > 0)
-		ss << SAVE_PREFIX << "_";
-	ss << "stash";
+	ss << PATH_USER << SAVE_PREFIX << "_stash";
 	if (pc->stats.permadeath)
 		ss << "_HC" << game_slot;
 	ss << ".txt";
@@ -206,11 +199,7 @@ void GameStatePlay::loadGame() {
 	std::vector<int> hotkeys(ACTIONBAR_MAX, -1);
 
 	std::stringstream ss;
-	ss.str("");
-	ss << PATH_USER;
-	if (SAVE_PREFIX.length() > 0)
-		ss << SAVE_PREFIX << "_";
-	ss << "save" << game_slot << ".txt";
+	ss << PATH_USER << SAVE_PREFIX << "_save" << game_slot << ".txt";
 
 	if (infile.open(ss.str(), false)) {
 		while (infile.next()) {
@@ -388,11 +377,7 @@ void GameStatePlay::loadStash() {
 	// Load stash
 	FileParser infile;
 	std::stringstream ss;
-	ss.str("");
-	ss << PATH_USER;
-	if (SAVE_PREFIX.length() > 0)
-		ss << SAVE_PREFIX << "_";
-	ss << "stash";
+	ss << PATH_USER << SAVE_PREFIX << "_stash";
 	if (pc->stats.permadeath)
 		ss << "_HC" << game_slot;
 	ss << ".txt";

--- a/src/SaveLoad.cpp
+++ b/src/SaveLoad.cpp
@@ -40,6 +40,7 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 #include "MenuStash.h"
 #include "MenuTalker.h"
 #include "Settings.h"
+#include "Utils.h"
 #include "UtilsFileSystem.h"
 #include "UtilsParsing.h"
 #include "SharedGameResources.h"
@@ -52,6 +53,9 @@ void GameStatePlay::saveGame() {
 	// game slots are currently 1-4
 	if (game_slot == 0) return;
 
+	// if needed, create the save file structure
+	createSaveDir(game_slot);
+
 	// remove items with zero quantity from inventory
 	menu->inv->inventory[EQUIPMENT].clean();
 	menu->inv->inventory[CARRIED].clean();
@@ -59,7 +63,7 @@ void GameStatePlay::saveGame() {
 	std::ofstream outfile;
 
 	std::stringstream ss;
-	ss << PATH_USER << SAVE_PREFIX << "_save" << game_slot << ".txt";
+	ss << PATH_USER << SAVE_PREFIX << "/" << game_slot << "/avatar.txt";
 
 	outfile.open(ss.str().c_str(), std::ios::out);
 
@@ -157,10 +161,10 @@ void GameStatePlay::saveGame() {
 
 	// Save stash
 	ss.str("");
-	ss << PATH_USER << SAVE_PREFIX << "_stash";
 	if (pc->stats.permadeath)
-		ss << "_HC" << game_slot;
-	ss << ".txt";
+		ss << PATH_USER << SAVE_PREFIX << "/" << game_slot << "/stash_HC.txt";
+	else
+		ss << PATH_USER << SAVE_PREFIX << "/stash.txt";
 
 	outfile.open(ss.str().c_str(), std::ios::out);
 
@@ -199,7 +203,7 @@ void GameStatePlay::loadGame() {
 	std::vector<int> hotkeys(ACTIONBAR_MAX, -1);
 
 	std::stringstream ss;
-	ss << PATH_USER << SAVE_PREFIX << "_save" << game_slot << ".txt";
+	ss << PATH_USER << SAVE_PREFIX << "/" << game_slot << "/avatar.txt";
 
 	if (infile.open(ss.str(), false)) {
 		while (infile.next()) {
@@ -377,10 +381,10 @@ void GameStatePlay::loadStash() {
 	// Load stash
 	FileParser infile;
 	std::stringstream ss;
-	ss << PATH_USER << SAVE_PREFIX << "_stash";
 	if (pc->stats.permadeath)
-		ss << "_HC" << game_slot;
-	ss << ".txt";
+		ss << PATH_USER << SAVE_PREFIX << "/" << game_slot << "/stash_HC.txt";
+	else
+		ss << PATH_USER << SAVE_PREFIX << "/stash.txt";
 
 	if (infile.open(ss.str(), false)) {
 		while (infile.next()) {

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -519,6 +519,7 @@ void loadMiscSettings() {
 	CORPSE_TIMEOUT = 60*MAX_FRAMES_PER_SEC;
 	SELL_WITHOUT_VENDOR = true;
 	AIM_ASSIST = 0;
+	SAVE_PREFIX = "";
 	WINDOW_TITLE = "Flare";
 	SOUND_FALLOFF = 15;
 	PARTY_EXP_PERCENTAGE = 100;
@@ -587,6 +588,11 @@ void loadMiscSettings() {
 			else infile.error("Settings: '%s' is not a valid key.", infile.key.c_str());
 		}
 		infile.close();
+	}
+
+	if (SAVE_PREFIX == "") {
+		logError("Settings: save_prefix not found in engine/misc.txt, setting to 'default'. This may cause save file conflicts between games that have no save_prefix.");
+		SAVE_PREFIX = "default";
 	}
 
 	// @CLASS Settings: Resolution|Description of engine/resolutions.txt

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -220,16 +220,19 @@ void setPaths() {
 		createDir(PATH_USER);
 
 		PATH_CONF += "\\config";
-		PATH_USER += "\\saves";
+		PATH_USER += "\\userdata";
 		createDir(PATH_CONF);
 		createDir(PATH_USER);
 	}
 	else {
 		PATH_CONF = "config";
-		PATH_USER = "saves";
+		PATH_USER = "userdata";
 		createDir(PATH_CONF);
 		createDir(PATH_USER);
 	}
+
+	createDir(PATH_USER + "\\mods");
+	createDir(PATH_USER + "\\saves");
 
 	PATH_DATA = "";
 	if (dirExists(CUSTOM_PATH_DATA)) PATH_DATA = CUSTOM_PATH_DATA;
@@ -243,9 +246,11 @@ void setPaths() {
 void setPaths() {
 
 	PATH_CONF = std::string(SDL_AndroidGetInternalStoragePath()) + "/config";
-	PATH_USER = std::string(SDL_AndroidGetInternalStoragePath()) + "/saves";
+	PATH_USER = std::string(SDL_AndroidGetInternalStoragePath()) + "/userdata";
 	createDir(PATH_CONF);
 	createDir(PATH_USER);
+	createDir(PATH_USER + "/mods");
+	createDir(PATH_USER + "/saves");
 
 	std::string mods_folder = "data/org.flare.app/files";
 
@@ -301,27 +306,24 @@ void setPaths() {
 	// $XDG_CONFIG_HOME/flare/
 	if (getenv("XDG_CONFIG_HOME") != NULL) {
 		PATH_CONF = (std::string)getenv("XDG_CONFIG_HOME") + "/flare/";
-		createDir(PATH_CONF);
 	}
 	// $HOME/.config/flare/
 	else if (getenv("HOME") != NULL) {
 		PATH_CONF = (std::string)getenv("HOME") + "/.config/";
 		createDir(PATH_CONF);
 		PATH_CONF += "flare/";
-		createDir(PATH_CONF);
 	}
 	// ./config/
 	else {
 		PATH_CONF = "./config/";
-		createDir(PATH_CONF);
 	}
+
+	createDir(PATH_CONF);
 
 	// set user path (save games)
 	// $XDG_DATA_HOME/flare/
 	if (getenv("XDG_DATA_HOME") != NULL) {
 		PATH_USER = (std::string)getenv("XDG_DATA_HOME") + "/flare/";
-		createDir(PATH_USER);
-		createDir(PATH_USER + "mods/");
 	}
 	// $HOME/.local/share/flare/
 	else if (getenv("HOME") != NULL) {
@@ -330,14 +332,15 @@ void setPaths() {
 		PATH_USER += "share/";
 		createDir(PATH_USER);
 		PATH_USER += "flare/";
-		createDir(PATH_USER);
-		createDir(PATH_USER + "mods/");
 	}
 	// ./saves/
 	else {
-		PATH_USER = "./saves/";
-		createDir(PATH_USER);
+		PATH_USER = "./userdata/";
 	}
+
+	createDir(PATH_USER);
+	createDir(PATH_USER + "mods/");
+	createDir(PATH_USER + "saves/");
 
 	// data folder
 	// while PATH_CONF and PATH_USER are created if not found,

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -298,7 +298,7 @@ void createSaveDir(int slot) {
 	if (slot == 0) return;
 
 	std::stringstream ss;
-	ss << PATH_USER << SAVE_PREFIX << "/";
+	ss << PATH_USER << "saves/" << SAVE_PREFIX << "/";
 
 	createDir(ss.str());
 
@@ -311,7 +311,7 @@ void removeSaveDir(int slot) {
 	if (slot == 0) return;
 
 	std::stringstream ss;
-	ss << PATH_USER << SAVE_PREFIX << "/" << slot;
+	ss << PATH_USER << "saves/" << SAVE_PREFIX << "/" << slot;
 
 	if (isDirectory(ss.str())) {
 		removeDirRecursive(ss.str());

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -21,6 +21,7 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 #include "Settings.h"
 #include "SharedResources.h"
 #include "Utils.h"
+#include "UtilsFileSystem.h"
 
 #include <cmath>
 #include <stdarg.h>
@@ -290,5 +291,30 @@ void logError(const char* format, ...) {
 #endif
 
 	va_end(args);
+}
+
+void createSaveDir(int slot) {
+	// game slots are currently 1-4
+	if (slot == 0) return;
+
+	std::stringstream ss;
+	ss << PATH_USER << SAVE_PREFIX << "/";
+
+	createDir(ss.str());
+
+	ss << slot;
+	createDir(ss.str());
+}
+
+void removeSaveDir(int slot) {
+	// game slots are currently 1-4
+	if (slot == 0) return;
+
+	std::stringstream ss;
+	ss << PATH_USER << SAVE_PREFIX << "/" << slot;
+
+	if (isDirectory(ss.str())) {
+		removeDirRecursive(ss.str());
+	}
 }
 

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -151,4 +151,7 @@ void alignFPoint(FPoint *pos);
 void logInfo(const char* format, ...);
 void logError(const char* format, ...);
 
+void createSaveDir(int slot);
+void removeSaveDir(int slot);
+
 #endif

--- a/src/UtilsFileSystem.cpp
+++ b/src/UtilsFileSystem.cpp
@@ -144,3 +144,53 @@ int getDirList(std::string dir, std::vector<std::string> &dirs) {
 	closedir(dp);
 	return 0;
 }
+
+bool removeFile(const std::string file) {
+	if (remove(file.c_str()) != 0) {
+		perror("removeFile");
+		return false;
+	}
+	return true;
+}
+
+bool removeDir(const std::string dir) {
+	if (!isDirectory(dir))
+		return false;
+
+#ifndef _WIN32
+	// *nix implementation
+	if (rmdir(dir.c_str()) == -1) {
+		perror("removeDir");
+		return false;
+	}
+#endif
+
+#ifdef _WIN32
+	// win implementation
+	std::string syscmd = "rmdir " + path;
+	system(syscmd.c_str());
+#endif
+
+	return true;
+}
+
+bool removeDirRecursive(const std::string dir) {
+	std::vector<std::string> dir_list;
+	std::vector<std::string> file_list;
+
+	getDirList(dir, dir_list);
+	while (!dir_list.empty()) {
+		removeDirRecursive(dir + "/" + dir_list.back());
+		dir_list.pop_back();
+	}
+
+	getFileList(dir, "txt", file_list);
+	while (!file_list.empty()) {
+		removeFile(file_list.back());
+		file_list.pop_back();
+	}
+
+	removeDir(dir);
+
+	return true;
+}

--- a/src/UtilsFileSystem.h
+++ b/src/UtilsFileSystem.h
@@ -36,4 +36,8 @@ int getDirList(std::string dir, std::vector<std::string> &dirs);
 
 bool isDirectory(const std::string &path);
 
+bool removeFile(const std::string file);
+bool removeDir(const std::string dir);
+bool removeDirRecursive(const std::string dir);
+
 #endif


### PR DESCRIPTION
Closes #1348

If you are on a *nix system, I have created a script that will copy your existing save files to the new layout:
https://gist.github.com/dorkster/bdaac218d29ac0ae5220
Just run that script from you PATH_USER directory (`~/.local/share/flare/` in most cases) and you'll get a "saves" directory that looks like this:
```
saves/
├── empyrean
│   ├── 1
│   │   └── avatar.txt
│   └── stash.txt
├── f_campaign
│   ├── 1
│   │   └── avatar.txt
│   ├── 2
│   │   └── avatar.txt
│   └── stash.txt
├── flare0.19
│   ├── 1
│   │   └── avatar.txt
│   ├── 2
│   │   └── avatar.txt
│   ├── 4
│   │   ├── avatar.txt
│   │   └── stash_HC.txt
│   └── stash.txt
└── poly
    ├── 1
    │   └── avatar.txt
    ├── 2
    │   └── avatar.txt
    ├── 4
    │   └── avatar.txt
    └── stash.txt
```

