### PR TITLE
Fix local variable name for win32-conditional

### DIFF
--- a/src/UtilsFileSystem.cpp
+++ b/src/UtilsFileSystem.cpp
@@ -167,7 +167,7 @@ bool removeDir(const std::string dir) {
 
 #ifdef _WIN32
 	// win implementation
-	std::string syscmd = "rmdir " + path;
+	std::string syscmd = "rmdir " + dir;
 	system(syscmd.c_str());
 #endif
 


### PR DESCRIPTION
Local variable was named "path" but should be "dir" because "path" does not exist. Probably overlooked because the offending line is wrapped in a _WIN32-conditional and therefore a compiler error is only thrown on Windows machines.