### PR TITLE
Ignore OS X .DS_Store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ flare-android-project/jni/SDL2_ttf/
 flare-android-project/libs/
 flare-android-project/obj/
 flare-android-project/gen/
+
+# os x
+.DS_Store


### PR DESCRIPTION
Makes flare-engine hacking on a mac just a little bit better.