### PR TITLE
Load a maximum of enemies when entering a new map

### DIFF
--- a/src/EnemyGroupManager.cpp
+++ b/src/EnemyGroupManager.cpp
@@ -120,3 +120,12 @@ Enemy_Level EnemyGroupManager::getRandomEnemy(const std::string& category, int m
 		return enemyCandidates[rand() % enemyCandidates.size()];
 	}
 }
+
+std::vector<Enemy_Level> EnemyGroupManager::getEnemiesInCategory(const std::string& category) const {
+	std::map<std::string, std::vector<Enemy_Level> >::const_iterator it = _categories.find(category);
+	if (it == _categories.end()) {
+		logError("EnemyGroupManager: Could not find enemy category %s, returning empty enemy list", category.c_str());
+		return std::vector<Enemy_Level>();
+	}
+	return it->second;
+}

--- a/src/EnemyGroupManager.h
+++ b/src/EnemyGroupManager.h
@@ -53,6 +53,15 @@ public:
 	 */
 	Enemy_Level getRandomEnemy(const std::string& category, int minlevel, int maxlevel) const;
 
+	/** To get enemies that fit in a category
+	 *
+	 * @param category Enemies of the desired category
+	 *
+	 * @return Level descriptions of enemies in the category.
+	 *         Empty buffer if none was found.
+	 */
+	std::vector<Enemy_Level> getEnemiesInCategory(const std::string& category) const;
+
 private:
 
 	/** Container to store enemy data */

--- a/src/EnemyManager.cpp
+++ b/src/EnemyManager.cpp
@@ -170,6 +170,18 @@ void EnemyManager::handleNewMap () {
 		mapr->collider.block(e->stats.pos.x, e->stats.pos.y, true);
 	}
 
+	// load enemies that can be spawn by avatar's powers
+	for (size_t i = 0; i < pc->stats.powers_list.size(); i++) {
+		int power_index = pc->stats.powers_list[i];
+		std::string spwan_type = powers->getPower(power_index).spawn_type;
+		if (spwan_type != "") {
+			std::vector<Enemy_Level> spawn_enemies = enemyg->getEnemiesInCategory(spwan_type);
+			for (size_t j = 0; j < spawn_enemies.size(); j++) {
+				loadEnemyPrototype(spawn_enemies[j].type);
+			}
+		}
+	}
+
 	anim->cleanUp();
 }
 

--- a/src/EnemyManager.cpp
+++ b/src/EnemyManager.cpp
@@ -195,6 +195,18 @@ void EnemyManager::handleNewMap () {
 		}
 	}
 
+	// load enemies that can be spawn by map events
+	for (size_t i = 0; i < mapr->events.size(); i++) {
+		for (size_t j = 0; j < mapr->events[i].components.size(); j++) {
+			if (mapr->events[i].components[j].type == "spawn") {
+				std::vector<Enemy_Level> spawn_enemies = enemyg->getEnemiesInCategory(mapr->events[i].components[j].s);
+				for (size_t k = 0; k < spawn_enemies.size(); k++) {
+					loadEnemyPrototype(spawn_enemies[k].type);
+				}
+			}
+		}
+	}
+
 	anim->cleanUp();
 }
 

--- a/src/EnemyManager.cpp
+++ b/src/EnemyManager.cpp
@@ -182,6 +182,19 @@ void EnemyManager::handleNewMap () {
 		}
 	}
 
+	// load enemies that can be spawn by powers in the action bar
+	if (menu_act != NULL) {
+		for (size_t i = 0; i < menu_act->hotkeys.size(); i++) {
+			int power_index = menu_act->hotkeys[i];
+			if (power_index != 0 && powers->getPower(power_index).spawn_type != "") {
+				std::vector<Enemy_Level> spawn_enemies = enemyg->getEnemiesInCategory(powers->getPower(power_index).spawn_type);
+				for (size_t j = 0; j < spawn_enemies.size(); j++) {
+					loadEnemyPrototype(spawn_enemies[j].type);
+				}
+			}
+		}
+	}
+
 	anim->cleanUp();
 }
 

--- a/src/EnemyManager.h
+++ b/src/EnemyManager.h
@@ -42,6 +42,7 @@ private:
 	 * callee is responsible for deleting returned enemy object
 	 */
 	Enemy *getEnemyPrototype(const std::string& type_id);
+	size_t loadEnemyPrototype(const std::string& type_id);
 
 	std::vector<Enemy> prototypes;
 

--- a/src/MenuActionBar.cpp
+++ b/src/MenuActionBar.cpp
@@ -716,6 +716,7 @@ void MenuActionBar::addPower(const int id, const int target_id) {
 
 MenuActionBar::~MenuActionBar() {
 
+	menu_act = NULL;
 	if (emptyslot)
 		delete emptyslot;
 	if (disabled)


### PR DESCRIPTION
Fixes #1385 by having the EnemyManager do it's best effort to preload enemies that can spawn on a new map.

This is an implementation of the second idea proposed in the ticket. I think it is not especially convoluted while we accept that there will always be scenarios that require a load a runtime (ex: the player loot a new summoning scroll and use it immediatly). So to proposed patches focus on handling most common sources of creature spawn.

The first patch implements the (very tiny) refactoring necessary to load an enemy template without actually spawning it and use that to preload enemies that can be spawn by an enemy present on the map. This is the biggest patch since it contains the design changes plus the recursive check for preloading enemies that can summon enemies.

The second patch checks for avatar's powers that can summon enemies. The third patch checks powers in the action bar of the player and the fourth checks events on the new map.