### PR TITLE
Remove unused method (removeEquipped)

### DIFF
--- a/src/MenuInventory.cpp
+++ b/src/MenuInventory.cpp
@@ -681,14 +681,6 @@ bool MenuInventory::remove(int item) {
 	return true;
 }
 
-/**
- * Remove an equipped item from the player's inventory.
- */
-void MenuInventory::removeEquipped(int item) {
-	inventory[EQUIPMENT].remove(item);
-	applyEquipment();
-}
-
 void MenuInventory::removeFromPrevSlot(int quantity) {
 	if (drag_prev_src > -1 && inventory[drag_prev_src].drag_prev_slot > -1) {
 		int drag_prev_slot = inventory[drag_prev_src].drag_prev_slot;

--- a/src/MenuInventory.h
+++ b/src/MenuInventory.h
@@ -88,7 +88,6 @@ public:
 
 	bool add(ItemStack stack, int area, int slot, bool play_sound, bool auto_equip);
 	bool remove(int item);
-	void removeEquipped(int item);
 	void removeFromPrevSlot(int quantity);
 	void addCurrency(int count);
 	void removeCurrency(int count);


### PR DESCRIPTION
Marked as unused by Cppcheck. 

Tested a bit by moving items around in my inventory afterwards but didn't notice any difference without it.