### PR TITLE
Some code cleaning

### DIFF
--- a/src/Entity.cpp
+++ b/src/Entity.cpp
@@ -243,24 +243,7 @@ bool Entity::takeHit(Hazard &h) {
 	// prepare the combat text
 	CombatText *combat_text = comb;
 
-	// if it's a miss, do nothing
-	int accuracy = h.accuracy;
-	if(powers->powers[h.power_index].mod_accuracy_mode == STAT_MODIFIER_MODE_MULTIPLY)
-		accuracy = accuracy * powers->powers[h.power_index].mod_accuracy_value / 100;
-	else if(powers->powers[h.power_index].mod_accuracy_mode == STAT_MODIFIER_MODE_ADD)
-		accuracy += powers->powers[h.power_index].mod_accuracy_value;
-	else if(powers->powers[h.power_index].mod_accuracy_mode == STAT_MODIFIER_MODE_ABSOLUTE)
-		accuracy = powers->powers[h.power_index].mod_accuracy_value;
-
-	int avoidance = 0;
-	if(!powers->powers[h.power_index].trait_avoidance_ignore) {
-		avoidance = stats.get(STAT_AVOIDANCE);
-	}
-
-	int true_avoidance = 100 - (accuracy - avoidance);
-	clampFloor(true_avoidance, MIN_AVOIDANCE);
-	clampCeil(true_avoidance, MAX_AVOIDANCE);
-
+	//check if it is missile, and if it has to be reflected
 	if (h.missile && percentChance(stats.get(STAT_REFLECT))) {
 		// reflect the missile 180 degrees
 		h.setAngle(h.angle+static_cast<float>(M_PI));
@@ -280,11 +263,6 @@ bool Entity::takeHit(Hazard &h) {
 		}
 
 		return false;
-	}
-
-	bool missed = false;
-	if (percentChance(true_avoidance)) {
-		missed = true;
 	}
 
 	// calculate base damage
@@ -366,6 +344,28 @@ bool Entity::takeHit(Hazard &h) {
 	}
 
 	// misses cause reduced damage
+	int accuracy = h.accuracy;
+	if(powers->powers[h.power_index].mod_accuracy_mode == STAT_MODIFIER_MODE_MULTIPLY)
+		accuracy *= powers->powers[h.power_index].mod_accuracy_value / 100;
+	else if(powers->powers[h.power_index].mod_accuracy_mode == STAT_MODIFIER_MODE_ADD)
+		accuracy += powers->powers[h.power_index].mod_accuracy_value;
+	else if(powers->powers[h.power_index].mod_accuracy_mode == STAT_MODIFIER_MODE_ABSOLUTE)
+		accuracy = powers->powers[h.power_index].mod_accuracy_value;
+
+	int avoidance = 0;
+	if(!powers->powers[h.power_index].trait_avoidance_ignore) {
+		avoidance = stats.get(STAT_AVOIDANCE);
+	}
+
+	int true_avoidance = 100 - (accuracy - avoidance);
+	clampFloor(true_avoidance, MIN_AVOIDANCE);
+	clampCeil(true_avoidance, MAX_AVOIDANCE);
+
+	bool missed = false;
+	if (percentChance(true_avoidance)) {
+		missed = true;
+	}
+
 	if (missed) {
 		dmg = (dmg * randBetween(MIN_MISS_DAMAGE, MAX_MISS_DAMAGE)) / 100;
 	}


### PR DESCRIPTION
The changes are very minor.

At first, there were usings of `accuracy += ...` and `accuracy = accuracy * ...` in same place. So, in my opinion, it's better to keep just one style.

At second, comment "if it's miss do nothing" now is not actual, because we DO reducing damage. So I removed that comment and moved whole block with accuracy closer to reduction block, to keep all related stuff in one place.

If my changes are wrong, please, tell why, so in future I'll be able to bear it in mind.