### PR TITLE
Add Checkboxes to toggle sound and music on/off

### DIFF
--- a/mods/default/menus/config.txt
+++ b/mods/default/menus/config.txt
@@ -19,6 +19,8 @@ test_note=288,164
 [audio]
 music_volume=240,40,256,32
 sound_volume=240,72,256,64
+mute_music_volume=240,104,256,96
+mute_sound_volume=240,136,256,128
 
 [interface]
 language=64,16,32,32

--- a/mods/gcw0_defaults/engine/default_settings.txt
+++ b/mods/gcw0_defaults/engine/default_settings.txt
@@ -11,6 +11,8 @@ resolution_h=480
 # music and sound volume (0 = silent, 128 = max)
 music_volume=96
 sound_volume=128
+mute_music_volume=0
+mute_sound_volume=0
 
 # display floating damage text. 1 enable, 0 disable.
 combat_text=1

--- a/src/GameStateConfigBase.cpp
+++ b/src/GameStateConfigBase.cpp
@@ -74,6 +74,10 @@ GameStateConfigBase::GameStateConfigBase (bool do_init)
 	, music_volume_lb(new WidgetLabel())
 	, sound_volume_sl(new WidgetSlider())
 	, sound_volume_lb(new WidgetLabel())
+	, mute_sound_volume_cb(new WidgetCheckBox())
+	, mute_sound_volume_lb(new WidgetLabel())
+	, mute_music_volume_cb(new WidgetCheckBox())
+	, mute_music_volume_lb(new WidgetLabel())
 	, activemods_lstb(new WidgetListBox(10))
 	, activemods_lb(new WidgetLabel())
 	, inactivemods_lstb(new WidgetListBox(10))
@@ -214,6 +218,14 @@ bool GameStateConfigBase::parseKey(FileParser &infile, int &x1, int &y1, int &x2
 		// @ATTR sound_volume|int, int, int, int : Label X, Label Y, Widget X, Widget Y|Position of the "Sound Volume" slider relative to the frame.
 		placeLabeledWidget(sound_volume_lb, sound_volume_sl, x1, y1, x2, y2, msg->get("Sound Volume"), JUSTIFY_RIGHT);
 	}
+	else if (infile.key == "mute_music_volume") {
+		// @ATTR mute_music_volume|int, int, int, int : Label X, Label Y, Widget X, Widget Y|Position of the "Mute Music Volume" checkbox relative to the frame.
+		placeLabeledWidget(mute_music_volume_lb, mute_music_volume_cb, x1, y1, x2, y2, msg->get("Mute Music Volume"), JUSTIFY_RIGHT);
+	}
+	else if (infile.key == "mute_sound_volume") {
+		// @ATTR mute_sound_volume|int, int, int, int : Label X, Label Y, Widget X, Widget Y|Position of the "Mute Sound Volume" checkbox relative to the frame.
+		placeLabeledWidget(mute_sound_volume_lb, mute_sound_volume_cb, x1, y1, x2, y2, msg->get("Mute Sound Volume"), JUSTIFY_RIGHT);
+	}
 	else if (infile.key == "language") {
 		// @ATTR language|int, int, int, int : Label X, Label Y, Widget X, Widget Y|Position of the "Language" list box relative to the frame.
 		placeLabeledWidget(language_lb, language_lstb, x1, y1, x2, y2, msg->get("Language"));
@@ -353,6 +365,11 @@ void GameStateConfigBase::addChildWidgets() {
 	addChildWidget(sound_volume_sl, AUDIO_TAB);
 	addChildWidget(sound_volume_lb, AUDIO_TAB);
 
+	addChildWidget(mute_music_volume_cb, AUDIO_TAB);
+	addChildWidget(mute_music_volume_lb, AUDIO_TAB);
+	addChildWidget(mute_sound_volume_cb, AUDIO_TAB);
+	addChildWidget(mute_sound_volume_lb, AUDIO_TAB);
+
 	addChildWidget(combat_text_cb, INTERFACE_TAB);
 	addChildWidget(combat_text_lb, INTERFACE_TAB);
 	addChildWidget(show_fps_cb, INTERFACE_TAB);
@@ -395,6 +412,8 @@ void GameStateConfigBase::setupTabList() {
 
 	tablist_audio.add(music_volume_sl);
 	tablist_audio.add(sound_volume_sl);
+	tablist_audio.add(mute_music_volume_cb);
+	tablist_audio.add(mute_sound_volume_cb);
 	tablist_audio.setPrevTabList(&tablist);
 	tablist_audio.setNextTabList(&tablist_main);
 	tablist_audio.lock();
@@ -434,6 +453,18 @@ void GameStateConfigBase::updateAudio() {
 		snd->setVolumeMusic(MUSIC_VOLUME);
 		sound_volume_sl->set(0,128,SOUND_VOLUME);
 		snd->setVolumeSFX(SOUND_VOLUME);
+
+		if(MUSIC_OFF == false) mute_music_volume_cb->unCheck();
+		else {
+			mute_music_volume_cb->Check();
+			snd->setVolumeMusic(0);
+		}
+
+		if(SOUND_OFF == false) mute_sound_volume_cb->unCheck();
+		else {
+			mute_sound_volume_cb->Check();
+			snd->setVolumeSFX(0);
+		}
 	}
 	else {
 		music_volume_sl->set(0,128,0);
@@ -604,15 +635,35 @@ void GameStateConfigBase::logicCancel() {
 
 void GameStateConfigBase::logicAudio() {
 	if (AUDIO) {
-		if (music_volume_sl->checkClick()) {
+		if (!MUSIC_OFF && music_volume_sl->checkClick()) {
 			if (MUSIC_VOLUME == 0)
 				reload_music = true;
 			MUSIC_VOLUME = static_cast<short>(music_volume_sl->getValue());
 			snd->setVolumeMusic(MUSIC_VOLUME);
 		}
-		else if (sound_volume_sl->checkClick()) {
+		else if (!SOUND_OFF && sound_volume_sl->checkClick()) {
 			SOUND_VOLUME = static_cast<short>(sound_volume_sl->getValue());
 			snd->setVolumeSFX(SOUND_VOLUME);
+		}
+		else if (mute_music_volume_cb->checkClick()) {
+			if (mute_music_volume_cb->isChecked()) {
+				MUSIC_OFF=true;
+				snd->setVolumeMusic(0);
+			}
+			else {
+				MUSIC_OFF=false;
+				snd->setVolumeMusic(MUSIC_VOLUME);
+			}
+		}
+		else if (mute_sound_volume_cb->checkClick()) {
+			if (mute_sound_volume_cb->isChecked()) {
+				SOUND_OFF=true;
+				snd->setVolumeSFX(0);
+			}
+			else {
+				SOUND_OFF=false;
+				snd->setVolumeSFX(SOUND_VOLUME);
+			}
 		}
 	}
 }

--- a/src/GameStateConfigBase.h
+++ b/src/GameStateConfigBase.h
@@ -127,6 +127,10 @@ public:
 	WidgetLabel         * music_volume_lb;
 	WidgetSlider        * sound_volume_sl;
 	WidgetLabel         * sound_volume_lb;
+	WidgetCheckBox			* mute_sound_volume_cb;
+	WidgetLabel					* mute_sound_volume_lb;
+	WidgetCheckBox			* mute_music_volume_cb;
+	WidgetLabel					* mute_music_volume_lb;
 	WidgetListBox       * activemods_lstb;
 	WidgetLabel         * activemods_lb;
 	WidgetListBox       * inactivemods_lstb;

--- a/src/GameStateConfigBase.h
+++ b/src/GameStateConfigBase.h
@@ -127,10 +127,10 @@ public:
 	WidgetLabel         * music_volume_lb;
 	WidgetSlider        * sound_volume_sl;
 	WidgetLabel         * sound_volume_lb;
-	WidgetCheckBox			* mute_sound_volume_cb;
-	WidgetLabel					* mute_sound_volume_lb;
-	WidgetCheckBox			* mute_music_volume_cb;
-	WidgetLabel					* mute_music_volume_lb;
+	WidgetCheckBox      * mute_sound_volume_cb;
+	WidgetLabel         * mute_sound_volume_lb;
+	WidgetCheckBox      * mute_music_volume_cb;
+	WidgetLabel         * mute_music_volume_lb;
 	WidgetListBox       * activemods_lstb;
 	WidgetLabel         * activemods_lb;
 	WidgetListBox       * inactivemods_lstb;

--- a/src/MenuExit.h
+++ b/src/MenuExit.h
@@ -28,6 +28,7 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 #include "Menu.h"
 #include "WidgetButton.h"
 #include "WidgetSlider.h"
+#include "WidgetCheckBox.h"
 
 class MenuExit : public Menu {
 protected:
@@ -43,6 +44,9 @@ protected:
 
 	WidgetLabel music_volume_lb;
 	WidgetLabel sound_volume_lb;
+
+	WidgetCheckBox *mute_music_volume_cb;
+	WidgetCheckBox *mute_sound_volume_cb;
 
 	bool exitClicked;
 

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -63,6 +63,8 @@ ConfigEntry config[] = {
 	{ "resolution_h",      &typeid(SCREEN_H),           "480", &SCREEN_H,           NULL},
 	{ "music_volume",      &typeid(MUSIC_VOLUME),       "96",  &MUSIC_VOLUME,       "music and sound volume (0 = silent, 128 = max)"},
 	{ "sound_volume",      &typeid(SOUND_VOLUME),       "128", &SOUND_VOLUME,       NULL},
+	{ "mute_music_volume", &typeid(MUSIC_OFF),					"0",	 &MUSIC_OFF,					NULL},
+	{ "mute_sound_volume", &typeid(SOUND_OFF),					"0",	 &SOUND_OFF,					NULL},
 	{ "combat_text",       &typeid(COMBAT_TEXT),        "1",   &COMBAT_TEXT,        "display floating damage text. 1 enable, 0 disable."},
 	{ "mouse_move",        &typeid(MOUSE_MOVE),         "0",   &MOUSE_MOVE,         "use mouse to move (experimental). 1 enable, 0 disable."},
 	{ "hwsurface",         &typeid(HWSURFACE),          "1",   &HWSURFACE,          "hardware surfaces, v-sync. Try disabling for performance. 1 enable, 0 disable."},
@@ -140,6 +142,8 @@ std::string RENDER_DEVICE;
 bool AUDIO = true;
 unsigned short MUSIC_VOLUME;
 unsigned short SOUND_VOLUME;
+bool MUSIC_OFF;
+bool SOUND_OFF;
 
 // Interface Settings
 bool COMBAT_TEXT;

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -87,6 +87,8 @@ extern unsigned short ICON_SIZE;
 extern bool AUDIO;					// initialize the audio subsystem at all?
 extern unsigned short MUSIC_VOLUME;
 extern unsigned short SOUND_VOLUME;
+extern bool MUSIC_OFF;
+extern bool SOUND_OFF;
 extern bool FULLSCREEN;
 extern unsigned char BITS_PER_PIXEL;
 extern unsigned short MAX_FRAMES_PER_SEC;


### PR DESCRIPTION
Adds checkboxes on the Audio tab of the Configurations menu and on the Pause Menu (MenuExit).
When one of the checkboxes is checked, the value for that component (Sound / Music) is 0 and the slider is disabled (you can't move it), and when you uncheck it, the component value changes to the value before you checked it and the slider is enabled again.

To add/remove these checkboxes on the configurations menu, you should, on the menus/configs.txt file, add the lines:
```
mute_music_volume=240,104,256,96
mute_sound_volume=240,136,256,128
```
_These are the positions for the attached screenshots_

To add/remove these checkboxes on the exit menu, you should, on the menus/exit.txt file, add the lines:
```
mute_music_volume=159,32,270,52
mute_sound_volume=159,32,270,100
```
_These are the positions for the attached screenshots_

To set default values for the checkboxes, add on the engine/default_settings.txt file, add the lines:
```
mute_music_volume=0
mute_sound_volume=0
```
where 0 means the component isn't muted, 1 means it is muted.

Example of visuals _(Before change vs after change in the same photo)_ :
![15595562_1270223073016655_1197911605_o](https://cloud.githubusercontent.com/assets/11949809/21297246/197c6754-c574-11e6-8105-571af2a18d02.png)
![15609247_1270223093016653_1119403064_o](https://cloud.githubusercontent.com/assets/11949809/21297250/2d1528e6-c574-11e6-9a6b-1ccc2997ca5b.png)

