### PR TITLE
Optimized group_stack; implementd max_stacks

### DIFF
--- a/src/EffectManager.cpp
+++ b/src/EffectManager.cpp
@@ -355,14 +355,18 @@ void EffectManager::addEffect(EffectDef &effect, int duration, int magnitude, bo
 	e.source_type = source_type;
 
 	if(effect.max_stacks != -1 && stacks_applied >= effect.max_stacks){
-		//Replace the oldest effect of the type
-		effect_list[insert_pos-stacks_applied] = e;
-	}else{
-		if (insert_effect)
-			effect_list.insert(effect_list.begin() + insert_pos, e);
-		else
-			effect_list.push_back(e);
+		//Remove the oldest effect of the type
+		removeAnimation(insert_pos-stacks_applied);
+		effect_list.erase(effect_list.begin()+insert_pos-stacks_applied);
+
+		//All elemnts have shiftef to left
+		insert_pos--;
 	}
+
+	if (insert_effect)
+		effect_list.insert(effect_list.begin() + insert_pos, e);
+	else
+		effect_list.push_back(e);
 }
 
 void EffectManager::removeEffect(size_t id) {

--- a/src/MenuActiveEffects.cpp
+++ b/src/MenuActiveEffects.cpp
@@ -80,55 +80,44 @@ void MenuActiveEffects::logic() {
 
 	effect_icons.clear();
 
-	bool alreadyOn;
-
 	for (size_t i = 0; i < stats->effects.effect_list.size(); ++i) {
 		if (stats->effects.effect_list[i].icon == -1)
 			continue;
 
 		const Effect &ed = stats->effects.effect_list[i];
 
+		int most_recent_id;
 		if(ed.group_stack){
-			alreadyOn = false;
-			for(size_t j=0; j < effect_icons.size(); ++j){
-				if(effect_icons[j].type == ed.type && effect_icons[j].name == ed.name){
-					effect_icons[j].stacks++;
+			if( effect_icons.size()>0 
+				&& effect_icons[(most_recent_id=static_cast<int>(effect_icons.size())-1)].type == ed.type 
+				&& effect_icons[most_recent_id].name == ed.name){
 
-					if(ed.type == EFFECT_SHIELD){
-						if(ed.magnitude < effect_icons[j].overlay.y/ICON_SIZE*effect_icons[j].max){
-							effect_icons[j].overlay.y = (ICON_SIZE * ed.magnitude)/ ed.magnitude_max;
-						}
-						effect_icons[j].current += ed.magnitude;
-						effect_icons[j].max += ed.magnitude_max;
-					}else if (ed.type == EFFECT_HEAL){
-						//No special behavior
-					}else{
-						if(ed.ticks < effect_icons[j].current){
-							if (ed.duration > 0)
-								effect_icons[j].overlay.y = (ICON_SIZE * ed.ticks) / ed.duration;
-							else
-								effect_icons[j].overlay.y = ICON_SIZE;
-							effect_icons[j].current = ed.ticks;
-							effect_icons[j].max = ed.duration;
-						}
+				effect_icons[most_recent_id].stacks++;
+
+				if(ed.type == EFFECT_SHIELD){
+					//Shields stacks in momment of addition, we never have to reach that
+				}else if (ed.type == EFFECT_HEAL){
+					//No special behavior
+				}else{
+					if(ed.ticks < effect_icons[most_recent_id].current){
+						if (ed.duration > 0)
+							effect_icons[most_recent_id].overlay.y = (ICON_SIZE * ed.ticks) / ed.duration;
+						else
+							effect_icons[most_recent_id].overlay.y = ICON_SIZE;
+						effect_icons[most_recent_id].current = ed.ticks;
+						effect_icons[most_recent_id].max = ed.duration;
 					}
-
-					if(!effect_icons[j].stacksLabel){
-						effect_icons[j].stacksLabel = new WidgetLabel();
-
-						effect_icons[j].stacksLabel->setX(effect_icons[j].pos.x);
-						effect_icons[j].stacksLabel->setY(effect_icons[j].pos.y);
-						effect_icons[j].stacksLabel->setMaxWidth(ICON_SIZE);
-					}
-
-					effect_icons[j].stacksLabel->set(msg->get("x%d", effect_icons[j].stacks));
-
-					alreadyOn = true;
-					break;
 				}
-			}
 
-			if(alreadyOn){
+				if(!effect_icons[most_recent_id].stacksLabel){
+					effect_icons[most_recent_id].stacksLabel = new WidgetLabel();
+					effect_icons[most_recent_id].stacksLabel->setX(effect_icons[most_recent_id].pos.x);
+					effect_icons[most_recent_id].stacksLabel->setY(effect_icons[most_recent_id].pos.y);
+					effect_icons[most_recent_id].stacksLabel->setMaxWidth(ICON_SIZE);
+				}
+
+				effect_icons[most_recent_id].stacksLabel->set(msg->get("x%d", effect_icons[most_recent_id].stacks));
+
 				continue;
 			}
 		}

--- a/src/PowerManager.cpp
+++ b/src/PowerManager.cpp
@@ -99,6 +99,10 @@ void PowerManager::loadEffects() {
 			// @ATTR effect.can_stack|bool|Allows multiple instances of this effect
 			effects.back().can_stack = toBool(infile.val);
 		}
+		else if (infile.key == "max_stacks") {
+			// @ATTR effect.max_stacks|int|Maximum allowed instances of this effect, -1 for no limits
+			effects.back().max_stacks = toInt(infile.val);
+		}
 		else if (infile.key == "group_stack") {
 			// @ATTR effect.group_stack|bool|For effects that can stack, setting this to true will combine those effects into a single status icon.
 			effects.back().group_stack = toBool(infile.val);

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -185,6 +185,7 @@ public:
 	int icon;
 	std::string animation;
 	bool can_stack;
+	int max_stacks;
 	bool group_stack;
 	bool render_above;
 
@@ -195,6 +196,7 @@ public:
 		, icon(-1)
 		, animation("")
 		, can_stack(true)
+		, max_stacks(-1)
 		, group_stack(false)
 		, render_above(false) {
 	}


### PR DESCRIPTION
1) Shields now stacks in time of addition. It's nice, because (let max_magnitude be 27) "37/54" after taking 10 damage is now "27/54", not "27/27".
2) EffectDef now has field "max_stacks". It means:
a) For shields:
Current magnitude can't be greater than max_magintude*max_stacks. So, if u have max_stacks=2, and a shield "44/54", after casting another shield it'll be "54/54", not "54/81" or "71/81".
b) For other skills
If there're already max_stacks stacks of the effect on u, applying one more will overwrite the oldest one. So, if curse have max_stacks=3 and u have 3 curses with left durations (2, 3, 5), new curse will not just be ignorede, it will do the maximum he can (upgrades the "2").

But maybe we need (let max_duration=6) do not the (2,3,5)->(3,5,5) change, but  (2,3,5)->(5,5,6)? So, all 6 points will be spent.

It's realted to clintbellanger/flare-game/issues/533